### PR TITLE
docs: add security scanning alert triage policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,3 +175,4 @@ grep <tool> package.json       # Node.js: eslint, prettier, newman
 
 - Never commit credentials
 - Check `.gitignore` before committing
+- Code scanning alerts (Trivy): CI runner global packages → dismiss as "false positive"; K8S/Helm/Terraform/Dockerfile demo configs → dismiss as "won't fix"


### PR DESCRIPTION
## Summary
- Add security alert triage policy to CLAUDE.md Security section
- Documents dismiss strategy for Trivy code scanning alerts (false positive for CI runner global packages, won't fix for demo K8S/Helm/Terraform configs)

Closes #59