### PR TITLE
fix(ci): add explicit Newman assertion count verification (#72)

### DIFF
--- a/.github/workflows/api-testing-ci.yml
+++ b/.github/workflows/api-testing-ci.yml
@@ -60,6 +60,26 @@ jobs:
       - name: Run Newman tests
         run: npm test
 
+      - name: Verify assertion counts
+        run: |
+          REPORT="reports/newman-report.json"
+          if [ ! -f "$REPORT" ]; then
+            echo "ERROR: Newman JSON report not found at $REPORT"
+            exit 1
+          fi
+          TOTAL=$(jq '[.run.executions[].assertions // [] | length] | add // 0' "$REPORT")
+          FAILURES=$(jq '[.run.executions[].assertions // [] | map(select(.error)) | length] | add // 0' "$REPORT")
+          echo "Assertions: total=$TOTAL, failures=$FAILURES"
+          if [ "$TOTAL" -eq 0 ]; then
+            echo "ERROR: No assertions found — tests may have been skipped"
+            exit 1
+          fi
+          if [ "$FAILURES" -ne 0 ]; then
+            echo "ERROR: $FAILURES assertion(s) failed"
+            exit 1
+          fi
+          echo "OK: All $TOTAL assertions passed"
+
       - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

- Add "Verify assertion counts" step after Newman test run in `api-testing-ci.yml`
- Parses `newman-report.json` with `jq` to extract total and failed assertion counts
- Fails CI if no assertions found (catches skipped/empty test runs)
- Fails CI if any assertion failures exist (catches masked failures like #34)

## Test plan

- [x] YAML syntax valid (89 lines, single Verify step)
- [x] `jq` pre-installed on `ubuntu-latest`
- [x] `reports/newman-report.json` produced by `npm test` (--reporter-json-export)
- [ ] CI validates on push (this PR triggers `api-testing-ci.yml`)

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)