### PR TITLE
fix(ci): remove continue-on-error from non-cleanup CI steps (#76)

### DIFF
--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -81,7 +81,6 @@ jobs:
             --max-line-length=120 \
             --fail-under=8.0 \
             --disable=C0114,C0115,C0116,C0415,W1203,R0801,R0902,W0718 \
-        continue-on-error: true
 
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -73,10 +73,9 @@ jobs:
       # higher severity vulnerabilities."
       - name: Run npm audit (production dependencies)
         run: npm audit --omit=dev --audit-level=moderate
-        continue-on-error: true
 
       - name: Run npm audit (all dependencies with JSON output)
-        run: npm audit --json > npm-audit.json || true
+        run: npm audit --json > npm-audit.json
 
       - name: Generate npm audit report
         run: |

--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -222,7 +222,6 @@ jobs:
           mkdir -p reports
           safety check --json > reports/dependency-scan.json
           cat reports/dependency-scan.json
-        continue-on-error: true
 
       - name: Upload dependency report
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

- Remove `continue-on-error: true` from 3 non-cleanup CI steps across 3 workflows
- Remove `|| true` from npm audit JSON output step
- Keep `continue-on-error` only on `security-tests.yml` download artifacts (non-critical cleanup)

## Changes

| File | Step | Action |
|------|------|--------|
| `security-scan.yml` | npm audit (line 76) | Removed `continue-on-error` |
| `security-scan.yml` | npm audit JSON (line 79) | Removed `\|\| true` |
| `k8s-ci.yml` | pylint (line 84) | Removed `continue-on-error` |
| `security-tests.yml` | dependency scan (line 225) | Removed `continue-on-error` |
| `security-tests.yml` | download artifacts (line 244) | **Kept** (non-critical) |

## Test plan

- [x] Only `continue-on-error` on download artifacts remains (expected)
- [x] No `\|\| true` on security-critical steps
- [ ] CI validates on push

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)