### PR TITLE
fix(perf): postmortem improvements — k6 tag isolation, JMeter dry-run, Q1 report

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,7 @@ grep <tool> package.json       # Node.js: eslint, prettier, newman
 | `$(cmd)` 捕获数值必须清洗输出 | Node.js/Python 子进程可能输出 warning，污染 shell 变量导致 `-ge` 比较异常 | ISS-010 |
 | k6 `setup()` 请求必须用 tag 隔离 | setup/teardown 的 HTTP 请求计入全局 metrics，会污染 threshold 判定 | ISS-011 |
 | CI 绿灯 ≠ 测试通过，禁止 `continue-on-error` 掩盖失败 | 22 个 Newman 断言失败被隐藏，临时 workaround 变成永久遗留 | ISS-012, ISS-013 |
+| JMeter 正式测试前先 `npm run jmeter:dryrun` | 字段名/状态码错误在 dry-run 阶段拦截，避免全量测试浪费时间 | #50 |
 
 ## Wiki & Roadmap
 

--- a/docs/dev-process-checklist.md
+++ b/docs/dev-process-checklist.md
@@ -70,6 +70,7 @@
 - [ ] CI 流水线绿灯 → push 后检查 GitHub Actions → `.github/workflows/*.yml`
 - [ ] CI workaround 复验 → 移除所有 `continue-on-error`、`|| true`、`skip` 后再跑一次，确认真实结果为 0 failures（防止 #27/#34 假绿灯）
 - [ ] CI 报红验证 → 故意让测试失败一次，确认 CI 能正确检测到失败
+- [ ] JMeter dry-run 通过（如适用）→ `npm run jmeter:dryrun` 验证字段名和状态码正确（防止 #50 字段名错误）
 - [ ] 本地 pre-commit checklist 全部通过（参考根 CLAUDE.md Pre-commit Checklist）
 
 **评审要点：** lint 通过、所有测试 PASS、覆盖率达标、CI 绿灯且无 workaround 掩盖
@@ -151,6 +152,7 @@ Every new feature/project follows a 5-phase process. Each phase must pause for m
 - [ ] CI pipeline green → push then check GitHub Actions → `.github/workflows/*.yml`
 - [ ] CI workaround re-verification → remove all `continue-on-error`, `|| true`, `skip`, re-run and confirm 0 failures (prevent #27/#34 false green)
 - [ ] CI failure detection → intentionally break a test, confirm CI reports red
+- [ ] JMeter dry-run passes (if applicable) → `npm run jmeter:dryrun` verifies field names and status codes (prevent #50 field name mismatch)
 - [ ] Local pre-commit checklist fully passed (see root CLAUDE.md Pre-commit Checklist)
 
 **Review focus:** Lint passes, all tests PASS, coverage meets threshold, CI green with no workarounds masking failures


### PR DESCRIPTION
## Summary

- fix(perf): add setup() tag isolation and setupTimeout to all k6 scripts (#69)
- feat(perf): add JMeter dry-run verification step (#70)
- docs: add Q1 2026 postmortem analysis for 25 closed defects
- docs: add dry-run to checklist Phase 4 and CLAUDE.md Common Pitfalls

## Changes

| File | Change |
|------|--------|
| 5 k6 scripts | setup() tag isolation + setupTimeout |
| `scripts/jmeter-dryrun.sh` | New: 1 thread x 10s dry-run with .jtl validation |
| `tests/jmeter/config/dryrun.properties` | New: minimal dry-run config |
| `docs/postmortem-2026-Q1.md` | New: 25 defect analysis + improvement tracking |
| `docs/dev-process-checklist.md` | Phase 4: add dry-run step (CN + EN) |
| `CLAUDE.md` | Common Pitfalls: add dry-run rule |

## Test plan

- [x] `npm run jmeter:dryrun` — smoke 3/3 pass
- [x] `npm run jmeter:dryrun:auth` — auth 19/19 pass
- [x] `npm test` — 71 unit tests pass
- [x] k6 scripts validated with tag isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)