### PR TITLE
fix(perf): harden p0 coverage gate

### DIFF
--- a/performance-testing-platform/docs/project-management/postmortems/POSTMORTEM-2026-04-27-p0-04-coverage-false-fail.md
+++ b/performance-testing-platform/docs/project-management/postmortems/POSTMORTEM-2026-04-27-p0-04-coverage-false-fail.md
@@ -1,0 +1,104 @@
+# POSTMORTEM-2026-04-27 — P0-04 coverage false fail
+
+**类型:** Postmortem / RCA  
+**严重程度:** P0 gate false negative  
+**状态:** 已验证，P0-04 已恢复 PASS  
+**范围:** `performance-testing-platform`
+
+---
+
+## 1. 问题摘要
+
+`docs/qa/reports/p0-gate-report.md` 中 `P0-04` 显示覆盖率不达标：
+
+```text
+stmt=95.82% branch=92.64% func=100% line=97.37%
+```
+
+实际覆盖率全部高于门禁阈值：
+
+| 指标       | 实际值 | 阈值 | 判定 |
+| ---------- | ------ | ---- | ---- |
+| Statements | 95.82% | ≥80% | PASS |
+| Branches   | 92.64% | ≥70% | PASS |
+| Functions  | 100%   | ≥80% | PASS |
+| Lines      | 97.37% | ≥80% | PASS |
+
+---
+
+## 2. 影响范围
+
+| 项目                    | 影响                                   |
+| ----------------------- | -------------------------------------- |
+| Stage 4 P0 gate         | 旧报告将 `P0-04` 标为 FAIL，造成误判   |
+| `npm run test:coverage` | 无实际覆盖率缺口                       |
+| 合并决策                | 可能被错误阻塞，需要以新 gate 结果为准 |
+
+---
+
+## 3. RCA
+
+### 3.1 直接原因
+
+旧 `p0-gate-report.md` 是过期生成物，报告中的 `P0-04` 状态与当前 `coverage.log` 和当前脚本逻辑不一致。
+
+### 3.2 5 Why
+
+| 层级  | 问题                         | 原因                                                                           |
+| ----- | ---------------------------- | ------------------------------------------------------------------------------ |
+| Why 1 | 为什么 `P0-04` 显示 FAIL？   | 覆盖率数值达标，但阈值判断分支进入 FAIL                                        |
+| Why 2 | 为什么数值达标仍被判 FAIL？  | line coverage 变量在判断前被 Bash 改写                                         |
+| Why 3 | 为什么变量会被改写？         | 脚本使用 `LINES` 保存 line coverage，而 `LINES` 是 Bash 特殊变量，表示终端行数 |
+| Why 4 | 为什么测试未拦截？           | 旧测试只验证解析输出，没有检查脚本是否使用 Bash 特殊变量名                     |
+| Why 5 | 为什么问题表现为“显示达标”？ | `DETAIL` 先拼接了 `97.37%`，后续 `meets_threshold "$LINES"` 时变量值已被改写   |
+
+**根本原因:** `p0-gate-check.sh` 使用 Bash 特殊变量 `LINES` 保存 line coverage，变量在 TTY 环境下被自动维护为终端行数，导致阈值判断使用错误值。
+
+---
+
+## 4. 当前验证结果
+
+| 验证项                                           | 结果 | 说明                                                      |
+| ------------------------------------------------ | ---- | --------------------------------------------------------- |
+| `npm run test:coverage`                          | PASS | 33 suites / 312 tests；覆盖率 95.82 / 92.64 / 100 / 97.37 |
+| `npx bats tests/unit/scripts/p0-gate-check.bats` | PASS | 24 tests；覆盖 `LINES` 特殊变量禁用和 summary 解析        |
+| `bash scripts/p0-gate-check.sh`                  | PASS | P0-01 至 P0-05 全部通过                                   |
+
+---
+
+## 5. 修复与处置
+
+| 类型       | 处置                                                                         |
+| ---------- | ---------------------------------------------------------------------------- |
+| 覆盖率问题 | 无需补测覆盖率；实际 coverage 已达标                                         |
+| 配置修复   | `jest.config.js` 增加 `json-summary` reporter，生成机器可读 summary          |
+| 脚本修复   | `p0-gate-check.sh` 将 `LINES` 更名为 `LINE_COV`，避免 Bash 特殊变量冲突      |
+| 稳健性增强 | `p0-gate-check.sh` 读取 `coverage-summary.json`，不再依赖控制台表格判定      |
+| 回归测试   | `p0-gate-check.bats` 覆盖 `LINES` 禁用、summary 解析、达标 PASS、不达标 FAIL |
+| 报告处置   | 以重新生成的 P0 gate 报告为准，旧报告不得作为当前 gate 结论                  |
+| 后续风险   | 单独跟进 `P0-01` soak unit timeout，避免混淆为 coverage 失败                 |
+
+---
+
+## 6. Lessons Learned
+
+| 经验                                 | 后续约束                                                     |
+| ------------------------------------ | ------------------------------------------------------------ |
+| 生成报告可能滞后于脚本修复           | 判定 gate 状态时必须同时核对日志时间、分支和最新命令输出     |
+| Bash 特殊变量不能用于业务数据        | 避免 `LINES`、`COLUMNS`、`RANDOM` 等特殊变量名               |
+| 覆盖率门禁应使用机器可读数据         | 优先解析 `coverage-summary.json`，避免控制台输出格式影响结果 |
+| 数值显示达标但状态 FAIL 是强异常信号 | 优先检查解析链路和 artifact 时效，而不是盲目补覆盖率         |
+| P0 gate fail-late 会保留多个信号     | RCA 必须按检查项拆分，避免把 P0-01 失败归因到 P0-04          |
+
+---
+
+## 7. 关联文件
+
+| 文件                                    | 说明                                       |
+| --------------------------------------- | ------------------------------------------ |
+| `scripts/p0-gate-check.sh`              | P0-04 coverage gate 执行入口               |
+| `scripts/lib/gate-check-common.sh`      | `extract_coverage()` / `meets_threshold()` |
+| `jest.config.js`                        | coverage reporter 配置                     |
+| `tests/unit/scripts/p0-gate-check.bats` | P0 gate 阈值解析回归测试                   |
+| `docs/qa/reports/logs-p0/coverage.log`  | coverage 原始输出                          |
+| `docs/qa/reports/p0-gate-report.md`     | P0 gate 生成报告                           |

--- a/performance-testing-platform/docs/project-management/postmortems/README.md
+++ b/performance-testing-platform/docs/project-management/postmortems/README.md
@@ -5,11 +5,11 @@
 
 ## 1. 命名约定
 
-| 前缀 | 含义 | 适用场景 | 命名格式 |
-|------|------|----------|----------|
-| `RCA-` | Root Cause Analysis | 单点故障的技术根因追溯，聚焦因果链与修复 | `RCA-YYYY-MM-DD-<slug>.md` |
-| `INC-` | Incident | 事件型记录，侧重时间线、影响范围、响应过程 | `INC-YYYY-MM-DD-<slug>.md` |
-| `POSTMORTEM-` | Postmortem | 综合复盘，含根因、时间线、改进项、遗留风险 | `POSTMORTEM-YYYY-MM-DD-<slug>.md` |
+| 前缀          | 含义                | 适用场景                                   | 命名格式                          |
+| ------------- | ------------------- | ------------------------------------------ | --------------------------------- |
+| `RCA-`        | Root Cause Analysis | 单点故障的技术根因追溯，聚焦因果链与修复   | `RCA-YYYY-MM-DD-<slug>.md`        |
+| `INC-`        | Incident            | 事件型记录，侧重时间线、影响范围、响应过程 | `INC-YYYY-MM-DD-<slug>.md`        |
+| `POSTMORTEM-` | Postmortem          | 综合复盘，含根因、时间线、改进项、遗留风险 | `POSTMORTEM-YYYY-MM-DD-<slug>.md` |
 
 ### 选用建议
 
@@ -20,32 +20,34 @@
 
 ## 2. 当前归档
 
-| 文档 | 类型 | 说明 |
-|------|------|------|
-| [POSTMORTEM-2026-04-18-stage5-rate-limiter-integration-test.md](POSTMORTEM-2026-04-18-stage5-rate-limiter-integration-test.md) | Postmortem | Stage5 rate limiter 集成测试综合复盘 |
-| [INC-2026-04-21-jest-parallel-test-cpu-contention.md](INC-2026-04-21-jest-parallel-test-cpu-contention.md) | Incident | Jest 并行测试 CPU 争用假阳性 |
-| [INC-2026-04-21-preflight-script-manual-intervention.md](INC-2026-04-21-preflight-script-manual-intervention.md) | Incident | Preflight 脚本需人工介入 |
-| [RCA-2026-04-21-reports-dir-latent-bug.md](RCA-2026-04-21-reports-dir-latent-bug.md) | RCA | `reports/` 目录潜伏 Bug |
-| [RCA-2026-04-22-phase7-soak-delegation-regression.md](RCA-2026-04-22-phase7-soak-delegation-regression.md) | RCA | Phase 7 soak 委托缺失 |
-| [RCA-2026-04-23-merge-only-format-scope-test-failure.md](RCA-2026-04-23-merge-only-format-scope-test-failure.md) | RCA | merge ref 下 `format-scope` 测试脆弱 |
-| [RCA-2026-04-23-prettier-scope-drift.md](RCA-2026-04-23-prettier-scope-drift.md) | RCA | Prettier 检查范围漂移 |
-| [RCA-2026-04-24-bats-ci-detached-head-merge-commit.md](RCA-2026-04-24-bats-ci-detached-head-merge-commit.md) | RCA | BATS 在 CI detached HEAD + merge commit 下失败 |
-| [RCA-2026-04-24-broken-markdown-links-commit-15a3398.md](RCA-2026-04-24-broken-markdown-links-commit-15a3398.md) | RCA | scripts 重构引入 Markdown 断链 |
-| [RCA-2026-04-24-issue-192-193-grafana-readiness.md](RCA-2026-04-24-issue-192-193-grafana-readiness.md) | RCA | Grafana readiness 超时 + docker-compose `version` 字段过时（#192/#193） |
-| [POSTMORTEM-2026-04-25-stage4-integration-test-cluster.md](POSTMORTEM-2026-04-25-stage4-integration-test-cluster.md) | Postmortem | Stage 4 集成测试 #192–#195 集群事件复盘（断言层错配 + 依赖升级缺 preflight 体检） |
-| [RCA-2026-04-26-grafana-sqlite-lock.md](RCA-2026-04-26-grafana-sqlite-lock.md) | RCA | Grafana SQLite lock 导致 integration setup 阶段容器退出（#214） |
+| 文档                                                                                                                           | 类型             | 说明                                                                              |
+| ------------------------------------------------------------------------------------------------------------------------------ | ---------------- | --------------------------------------------------------------------------------- |
+| [POSTMORTEM-2026-04-18-stage5-rate-limiter-integration-test.md](POSTMORTEM-2026-04-18-stage5-rate-limiter-integration-test.md) | Postmortem       | Stage5 rate limiter 集成测试综合复盘                                              |
+| [INC-2026-04-21-jest-parallel-test-cpu-contention.md](INC-2026-04-21-jest-parallel-test-cpu-contention.md)                     | Incident         | Jest 并行测试 CPU 争用假阳性                                                      |
+| [INC-2026-04-21-preflight-script-manual-intervention.md](INC-2026-04-21-preflight-script-manual-intervention.md)               | Incident         | Preflight 脚本需人工介入                                                          |
+| [RCA-2026-04-21-reports-dir-latent-bug.md](RCA-2026-04-21-reports-dir-latent-bug.md)                                           | RCA              | `reports/` 目录潜伏 Bug                                                           |
+| [RCA-2026-04-22-phase7-soak-delegation-regression.md](RCA-2026-04-22-phase7-soak-delegation-regression.md)                     | RCA              | Phase 7 soak 委托缺失                                                             |
+| [RCA-2026-04-23-merge-only-format-scope-test-failure.md](RCA-2026-04-23-merge-only-format-scope-test-failure.md)               | RCA              | merge ref 下 `format-scope` 测试脆弱                                              |
+| [RCA-2026-04-23-prettier-scope-drift.md](RCA-2026-04-23-prettier-scope-drift.md)                                               | RCA              | Prettier 检查范围漂移                                                             |
+| [RCA-2026-04-24-bats-ci-detached-head-merge-commit.md](RCA-2026-04-24-bats-ci-detached-head-merge-commit.md)                   | RCA              | BATS 在 CI detached HEAD + merge commit 下失败                                    |
+| [RCA-2026-04-24-broken-markdown-links-commit-15a3398.md](RCA-2026-04-24-broken-markdown-links-commit-15a3398.md)               | RCA              | scripts 重构引入 Markdown 断链                                                    |
+| [RCA-2026-04-24-issue-192-193-grafana-readiness.md](RCA-2026-04-24-issue-192-193-grafana-readiness.md)                         | RCA              | Grafana readiness 超时 + docker-compose `version` 字段过时（#192/#193）           |
+| [POSTMORTEM-2026-04-25-stage4-integration-test-cluster.md](POSTMORTEM-2026-04-25-stage4-integration-test-cluster.md)           | Postmortem       | Stage 4 集成测试 #192–#195 集群事件复盘（断言层错配 + 依赖升级缺 preflight 体检） |
+| [RCA-2026-04-26-grafana-sqlite-lock.md](RCA-2026-04-26-grafana-sqlite-lock.md)                                                 | RCA              | Grafana SQLite lock 导致 integration setup 阶段容器退出（#214）                   |
+| [POSTMORTEM-2026-04-27-p0-04-coverage-false-fail.md](POSTMORTEM-2026-04-27-p0-04-coverage-false-fail.md)                       | Postmortem / RCA | P0-04 coverage 达标但旧报告误报 FAIL                                              |
 
 ## 3. 维护规则
 
-| 规则 | 说明 |
-|------|------|
-| 单事件单文档 | 同一事件原则上只保留一份，避免 RCA-/POSTMORTEM- 双份重复 |
-| 新增必更新 README | 每次新增文档须同步追加到第 2 节列表，保持可导航 |
-| 引用使用相对路径 | 跨文档引用统一使用相对路径，避免绝对链接失效 |
-| 关闭前明确状态 | 每份文档必须标注 `已完成 / 待执行 / 待评估`，避免悬空 TODO |
+| 规则              | 说明                                                       |
+| ----------------- | ---------------------------------------------------------- |
+| 单事件单文档      | 同一事件原则上只保留一份，避免 RCA-/POSTMORTEM- 双份重复   |
+| 新增必更新 README | 每次新增文档须同步追加到第 2 节列表，保持可导航            |
+| 引用使用相对路径  | 跨文档引用统一使用相对路径，避免绝对链接失效               |
+| 关闭前明确状态    | 每份文档必须标注 `已完成 / 待执行 / 待评估`，避免悬空 TODO |
 
 ## 4. 历史遗留
 
 - 2026-04-24 归档治理：合并 `postmortem-2026-04-23-*.md`（小写前缀）与 `RCA-2026-04-23-*.md` 重复文档，保留 `RCA-` 版本。
 - 2026-04-25 归档治理：删除小写前缀 `postmortem-2026-04-24-issue-192-193-grafana-readiness.md`（与同事件 `RCA-2026-04-24-issue-192-193-grafana-readiness.md` 重复，违反"单事件单文档"规则）；新增 `POSTMORTEM-2026-04-25-stage4-integration-test-cluster.md` 作为 #192–#195 集群事件的综合复盘。
 - 2026-04-26：新增 `RCA-2026-04-26-grafana-sqlite-lock.md`，闭环 #214 / DEF-009。
+- 2026-04-27：新增 `POSTMORTEM-2026-04-27-p0-04-coverage-false-fail.md`，闭环 P0-04 coverage 旧报告误报。

--- a/performance-testing-platform/jest.config.js
+++ b/performance-testing-platform/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   testMatch: ['**/tests/unit/**/*.test.js', '**/tests/integration/**/*.test.js'],
   collectCoverageFrom: ['src/**/*.js', '!src/server.js'],
   coverageDirectory: 'coverage',
+  coverageReporters: ['json', 'json-summary', 'lcov', 'text'],
   // Cap workers at 50% of CPUs: several "unit" suites spawn bash/node/python3
   // subprocesses (server-sh, preflight-check, integration-test-phase7-soak, lock).
   // Default (ncpu-1) saturates CPU → subprocess timeouts and jest-worker IPC crashes.

--- a/performance-testing-platform/scripts/lib/gate-check-common.sh
+++ b/performance-testing-platform/scripts/lib/gate-check-common.sh
@@ -84,6 +84,28 @@ extract_coverage() {
   }'
 }
 
+# extract_coverage_summary <coverage-summary.json>
+# 输出（空格分隔，4 列）：stmt branch funcs lines
+extract_coverage_summary() {
+  local summary_path="$1"
+  [ -f "$summary_path" ] || return 1
+
+  node - "$summary_path" << 'NODE'
+const fs = require('fs');
+
+const summaryPath = process.argv[2];
+const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+const total = summary.total || {};
+const values = ['statements', 'branches', 'functions', 'lines'].map((key) => total[key] && total[key].pct);
+
+if (values.some((value) => typeof value !== 'number')) {
+  process.exit(1);
+}
+
+process.stdout.write(values.join(' '));
+NODE
+}
+
 # meets_threshold <actual> <threshold>
 # 浮点比较（基于 awk）；actual >= threshold 返回 0
 meets_threshold() {

--- a/performance-testing-platform/scripts/p0-gate-check.sh
+++ b/performance-testing-platform/scripts/p0-gate-check.sh
@@ -154,22 +154,19 @@ fi
 echo ""
 echo "--- P0-04: 覆盖率 (npm run test:coverage) ---"
 COV_LOG="${LOG_DIR}/coverage.log"
-# 强制关闭 Jest 颜色输出，避免 ANSI 转义码污染 "All files" 行的数值解析
-# （macOS 终端或某些 CI 环境下 Jest 即使重定向到文件也会输出颜色）
+COV_SUMMARY="${COV_SUMMARY_PATH:-${PROJECT_DIR}/coverage/coverage-summary.json}"
+# 强制关闭 Jest 颜色输出；判定以 coverage-summary.json 为准，避免控制台表格格式影响门禁。
 if ! NO_COLOR=1 FORCE_COLOR=0 npm run test:coverage > "$COV_LOG" 2>&1; then
   log_result "P0-04" FAIL "覆盖率命令执行失败（详见 ${COV_LOG}）"
 else
-  ALL_LINE=$(grep -E "^All files" "$COV_LOG" | tail -1 || true)
-  if [ -z "$ALL_LINE" ]; then
-    log_result "P0-04" FAIL "未在覆盖率输出中找到 'All files' 行（详见 ${COV_LOG}）"
+  if ! read -r STMT BRANCH FUNCS LINE_COV <<< "$(extract_coverage_summary "$COV_SUMMARY")"; then
+    log_result "P0-04" FAIL "未能解析 coverage summary: ${COV_SUMMARY}（详见 ${COV_LOG}）"
   else
-    # 解析 4 列百分比
-    read -r STMT BRANCH FUNCS LINES <<< "$(extract_coverage "$ALL_LINE")"
-    DETAIL="stmt=${STMT}% branch=${BRANCH}% func=${FUNCS}% line=${LINES}%"
+    DETAIL="stmt=${STMT}% branch=${BRANCH}% func=${FUNCS}% line=${LINE_COV}%"
     if meets_threshold "$STMT" "$COV_STMT_MIN" \
       && meets_threshold "$BRANCH" "$COV_BRANCH_MIN" \
       && meets_threshold "$FUNCS" "$COV_FUNC_MIN" \
-      && meets_threshold "$LINES" "$COV_LINE_MIN"; then
+      && meets_threshold "$LINE_COV" "$COV_LINE_MIN"; then
       log_result "P0-04" PASS "覆盖率达标 (${DETAIL})"
     else
       log_result "P0-04" FAIL \

--- a/performance-testing-platform/tests/unit/scripts/p0-gate-check.bats
+++ b/performance-testing-platform/tests/unit/scripts/p0-gate-check.bats
@@ -73,6 +73,10 @@ EOF
   grep -qE 'set -[a-z]*u[a-z]*o pipefail' "$SCRIPT"
 }
 
+@test "前置: 覆盖率脚本不得使用 Bash 特殊变量 LINES 保存 line coverage" {
+  ! grep -Eq 'read .* LINES|\$LINES' "$SCRIPT"
+}
+
 # ============================================================
 # CLI / 帮助
 # ============================================================
@@ -132,6 +136,24 @@ EOF
   [[ "$output" == *"84.9"* ]]
 }
 
+@test "lib: extract_coverage_summary 从 coverage-summary.json 解析 total 百分比" {
+  local summary="${TEST_TMP}/coverage-summary.json"
+  cat > "$summary" << 'EOF'
+{
+  "total": {
+    "statements": { "pct": 95.82 },
+    "branches": { "pct": 92.64 },
+    "functions": { "pct": 100 },
+    "lines": { "pct": 97.37 }
+  }
+}
+EOF
+
+  run bash -c "source '$LIB'; extract_coverage_summary '$summary'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "95.82 92.64 100 97.37" ]
+}
+
 @test "lib: meets_threshold 大于等于阈值返回 0" {
   run bash -c "source '$LIB'; meets_threshold 80.0 80"
   [ "$status" -eq 0 ]
@@ -177,6 +199,7 @@ EOF
 
 @test "端到端: 5 项全 PASS 时退出码为 0 并生成报告" {
   # 写一个能识别所有 P0 命令的 mock
+  export COV_SUMMARY_PATH="${TEST_TMP}/coverage-summary.json"
   mkdir -p "$TEST_TMP/bin"
   cat > "$TEST_TMP/bin/npm" << 'EOF'
 #!/usr/bin/env bash
@@ -194,11 +217,9 @@ case "$1 $2" in
     exit 0
     ;;
   "run test:coverage")
-    cat << 'COV'
-File         | % Stmts | % Branch | % Funcs | % Lines |
--------------|---------|----------|---------|---------|
-All files    |   85.50 |    72.10 |   81.30 |   84.90 |
-COV
+    cat > "${COV_SUMMARY_PATH}" << 'JSON'
+{"total":{"statements":{"pct":85.50},"branches":{"pct":72.10},"functions":{"pct":81.30},"lines":{"pct":84.90}}}
+JSON
     exit 0
     ;;
   "run jmeter:dryrun")
@@ -228,6 +249,7 @@ EOF
 # ============================================================
 
 @test "端到端: 单元测试失败时整体退出码非 0（fail-late）" {
+  export COV_SUMMARY_PATH="${TEST_TMP}/coverage-summary.json"
   mkdir -p "$TEST_TMP/bin"
   cat > "$TEST_TMP/bin/npm" << 'EOF'
 #!/usr/bin/env bash
@@ -237,7 +259,9 @@ case "$1 $2" in
     exit 1
     ;;
   "run test:coverage")
-    echo "All files    |   85.50 |    72.10 |   81.30 |   84.90 |"
+    cat > "${COV_SUMMARY_PATH}" << 'JSON'
+{"total":{"statements":{"pct":85.50},"branches":{"pct":72.10},"functions":{"pct":81.30},"lines":{"pct":84.90}}}
+JSON
     exit 0
     ;;
   *) exit 0 ;;
@@ -257,12 +281,15 @@ EOF
 # ============================================================
 
 @test "端到端: 覆盖率 stmt < 80% 时 P0-04 应 FAIL" {
+  export COV_SUMMARY_PATH="${TEST_TMP}/coverage-summary.json"
   mkdir -p "$TEST_TMP/bin"
   cat > "$TEST_TMP/bin/npm" << 'EOF'
 #!/usr/bin/env bash
 case "$1 $2" in
   "run test:coverage")
-    echo "All files    |   75.50 |    72.10 |   81.30 |   84.90 |"
+    cat > "${COV_SUMMARY_PATH}" << 'JSON'
+{"total":{"statements":{"pct":75.50},"branches":{"pct":72.10},"functions":{"pct":81.30},"lines":{"pct":84.90}}}
+JSON
     exit 0
     ;;
   *) exit 0 ;;
@@ -278,12 +305,15 @@ EOF
 }
 
 @test "端到端: 覆盖率 branch < 70% 时 P0-04 应 FAIL" {
+  export COV_SUMMARY_PATH="${TEST_TMP}/coverage-summary.json"
   mkdir -p "$TEST_TMP/bin"
   cat > "$TEST_TMP/bin/npm" << 'EOF'
 #!/usr/bin/env bash
 case "$1 $2" in
   "run test:coverage")
-    echo "All files    |   85.50 |    65.10 |   81.30 |   84.90 |"
+    cat > "${COV_SUMMARY_PATH}" << 'JSON'
+{"total":{"statements":{"pct":85.50},"branches":{"pct":65.10},"functions":{"pct":81.30},"lines":{"pct":84.90}}}
+JSON
     exit 0
     ;;
   *) exit 0 ;;


### PR DESCRIPTION
## Summary
- Fix P0-04 false failure caused by Bash special variable `LINES` overwriting line coverage during threshold checks.
- Parse `coverage/coverage-summary.json` for machine-readable coverage values instead of relying on Jest console table output.
- Add Bats regression coverage and RCA/Postmortem documentation.

## Test Plan
- `npx prettier --check jest.config.js docs/project-management/postmortems/POSTMORTEM-2026-04-27-p0-04-coverage-false-fail.md docs/project-management/postmortems/README.md`
- `bash -n scripts/p0-gate-check.sh scripts/lib/gate-check-common.sh`
- `npx bats tests/unit/scripts/p0-gate-check.bats`
- `npm run lint`
- `bash scripts/p0-gate-check.sh`