### PR TITLE
fix(perf): require fresh coverage summary

### DIFF
--- a/performance-testing-platform/docs/project-management/postmortems/POSTMORTEM-2026-04-27-p0-04-coverage-false-fail.md
+++ b/performance-testing-platform/docs/project-management/postmortems/POSTMORTEM-2026-04-27-p0-04-coverage-false-fail.md
@@ -49,7 +49,7 @@ stmt=95.82% branch=92.64% func=100% line=97.37%
 | Why 1 | 为什么 `P0-04` 显示 FAIL？   | 覆盖率数值达标，但阈值判断分支进入 FAIL                                        |
 | Why 2 | 为什么数值达标仍被判 FAIL？  | line coverage 变量在判断前被 Bash 改写                                         |
 | Why 3 | 为什么变量会被改写？         | 脚本使用 `LINES` 保存 line coverage，而 `LINES` 是 Bash 特殊变量，表示终端行数 |
-| Why 4 | 为什么测试未拦截？           | 旧测试只验证解析输出，没有检查脚本是否使用 Bash 特殊变量名                     |
+| Why 4 | 为什么测试未拦截？           | 旧测试只验证解析输出，没有检查 Bash 特殊变量名或 stale summary                 |
 | Why 5 | 为什么问题表现为“显示达标”？ | `DETAIL` 先拼接了 `97.37%`，后续 `meets_threshold "$LINES"` 时变量值已被改写   |
 
 **根本原因:** `p0-gate-check.sh` 使用 Bash 特殊变量 `LINES` 保存 line coverage，变量在 TTY 环境下被自动维护为终端行数，导致阈值判断使用错误值。
@@ -61,22 +61,22 @@ stmt=95.82% branch=92.64% func=100% line=97.37%
 | 验证项                                           | 结果 | 说明                                                      |
 | ------------------------------------------------ | ---- | --------------------------------------------------------- |
 | `npm run test:coverage`                          | PASS | 33 suites / 312 tests；覆盖率 95.82 / 92.64 / 100 / 97.37 |
-| `npx bats tests/unit/scripts/p0-gate-check.bats` | PASS | 24 tests；覆盖 `LINES` 特殊变量禁用和 summary 解析        |
+| `npx bats tests/unit/scripts/p0-gate-check.bats` | PASS | 26 tests；覆盖 `LINES` 禁用、summary 新鲜度和解析失败     |
 | `bash scripts/p0-gate-check.sh`                  | PASS | P0-01 至 P0-05 全部通过                                   |
 
 ---
 
 ## 5. 修复与处置
 
-| 类型       | 处置                                                                         |
-| ---------- | ---------------------------------------------------------------------------- |
-| 覆盖率问题 | 无需补测覆盖率；实际 coverage 已达标                                         |
-| 配置修复   | `jest.config.js` 增加 `json-summary` reporter，生成机器可读 summary          |
-| 脚本修复   | `p0-gate-check.sh` 将 `LINES` 更名为 `LINE_COV`，避免 Bash 特殊变量冲突      |
-| 稳健性增强 | `p0-gate-check.sh` 读取 `coverage-summary.json`，不再依赖控制台表格判定      |
-| 回归测试   | `p0-gate-check.bats` 覆盖 `LINES` 禁用、summary 解析、达标 PASS、不达标 FAIL |
-| 报告处置   | 以重新生成的 P0 gate 报告为准，旧报告不得作为当前 gate 结论                  |
-| 后续风险   | 单独跟进 `P0-01` soak unit timeout，避免混淆为 coverage 失败                 |
+| 类型       | 处置                                                                                         |
+| ---------- | -------------------------------------------------------------------------------------------- |
+| 覆盖率问题 | 无需补测覆盖率；实际 coverage 已达标                                                         |
+| 配置修复   | `jest.config.js` 增加 `json-summary` reporter，生成机器可读 summary                          |
+| 脚本修复   | `p0-gate-check.sh` 将 `LINES` 更名为 `LINE_COV`，避免 Bash 特殊变量冲突                      |
+| 稳健性增强 | `p0-gate-check.sh` 读取 `coverage-summary.json`，不再依赖控制台表格判定                      |
+| 回归测试   | `p0-gate-check.bats` 覆盖 `LINES` 禁用、summary 新鲜度、summary 解析、达标 PASS、不达标 FAIL |
+| 报告处置   | 以重新生成的 P0 gate 报告为准，旧报告不得作为当前 gate 结论                                  |
+| 后续风险   | 单独跟进 `P0-01` soak unit timeout，避免混淆为 coverage 失败                                 |
 
 ---
 
@@ -87,6 +87,7 @@ stmt=95.82% branch=92.64% func=100% line=97.37%
 | 生成报告可能滞后于脚本修复           | 判定 gate 状态时必须同时核对日志时间、分支和最新命令输出     |
 | Bash 特殊变量不能用于业务数据        | 避免 `LINES`、`COLUMNS`、`RANDOM` 等特殊变量名               |
 | 覆盖率门禁应使用机器可读数据         | 优先解析 `coverage-summary.json`，避免控制台输出格式影响结果 |
+| 机器可读 artifact 必须由当前运行生成 | 运行 coverage 前删除旧 summary，并检查当前命令是否重新生成   |
 | 数值显示达标但状态 FAIL 是强异常信号 | 优先检查解析链路和 artifact 时效，而不是盲目补覆盖率         |
 | P0 gate fail-late 会保留多个信号     | RCA 必须按检查项拆分，避免把 P0-01 失败归因到 P0-04          |
 

--- a/performance-testing-platform/scripts/p0-gate-check.sh
+++ b/performance-testing-platform/scripts/p0-gate-check.sh
@@ -156,12 +156,16 @@ echo "--- P0-04: 覆盖率 (npm run test:coverage) ---"
 COV_LOG="${LOG_DIR}/coverage.log"
 COV_SUMMARY="${COV_SUMMARY_PATH:-${PROJECT_DIR}/coverage/coverage-summary.json}"
 # 强制关闭 Jest 颜色输出；判定以 coverage-summary.json 为准，避免控制台表格格式影响门禁。
+rm -f "$COV_SUMMARY"
 if ! NO_COLOR=1 FORCE_COLOR=0 npm run test:coverage > "$COV_LOG" 2>&1; then
   log_result "P0-04" FAIL "覆盖率命令执行失败（详见 ${COV_LOG}）"
 else
-  if ! read -r STMT BRANCH FUNCS LINE_COV <<< "$(extract_coverage_summary "$COV_SUMMARY")"; then
+  if [ ! -f "$COV_SUMMARY" ]; then
+    log_result "P0-04" FAIL "coverage summary 未生成: ${COV_SUMMARY}（详见 ${COV_LOG}）"
+  elif ! COVERAGE_VALUES="$(extract_coverage_summary "$COV_SUMMARY")"; then
     log_result "P0-04" FAIL "未能解析 coverage summary: ${COV_SUMMARY}（详见 ${COV_LOG}）"
   else
+    read -r STMT BRANCH FUNCS LINE_COV <<< "$COVERAGE_VALUES"
     DETAIL="stmt=${STMT}% branch=${BRANCH}% func=${FUNCS}% line=${LINE_COV}%"
     if meets_threshold "$STMT" "$COV_STMT_MIN" \
       && meets_threshold "$BRANCH" "$COV_BRANCH_MIN" \

--- a/performance-testing-platform/tests/unit/scripts/p0-gate-check.bats
+++ b/performance-testing-platform/tests/unit/scripts/p0-gate-check.bats
@@ -244,6 +244,53 @@ EOF
   [ -f "$GATE_REPORT_DIR/p0-gate-report.md" ]
 }
 
+@test "端到端: 覆盖率 summary 未重新生成时 P0-04 应 FAIL" {
+  export COV_SUMMARY_PATH="${TEST_TMP}/coverage-summary.json"
+  cat > "$COV_SUMMARY_PATH" << 'JSON'
+{"total":{"statements":{"pct":100},"branches":{"pct":100},"functions":{"pct":100},"lines":{"pct":100}}}
+JSON
+
+  mkdir -p "$TEST_TMP/bin"
+  cat > "$TEST_TMP/bin/npm" << 'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "run test:coverage")
+    echo "coverage command succeeded without summary"
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$TEST_TMP/bin/npm"
+  export PATH="$TEST_TMP/bin:$PATH"
+
+  run bash "$SCRIPT" --report-dir "$GATE_REPORT_DIR" --log-dir "$GATE_LOG_DIR"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"coverage summary 未生成"* ]]
+}
+
+@test "端到端: 覆盖率 summary 无效时 P0-04 应报告解析失败" {
+  export COV_SUMMARY_PATH="${TEST_TMP}/coverage-summary.json"
+  mkdir -p "$TEST_TMP/bin"
+  cat > "$TEST_TMP/bin/npm" << 'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "run test:coverage")
+    echo '{"total":{"statements":{"pct":95.82}}}' > "${COV_SUMMARY_PATH}"
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$TEST_TMP/bin/npm"
+  export PATH="$TEST_TMP/bin:$PATH"
+
+  run bash "$SCRIPT" --report-dir "$GATE_REPORT_DIR" --log-dir "$GATE_LOG_DIR"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"未能解析 coverage summary"* ]]
+  [[ "$output" != *"覆盖率不达标 (stmt=%"* ]]
+}
+
 # ============================================================
 # 端到端：单元测试失败场景
 # ============================================================


### PR DESCRIPTION
## Summary
- Require P0-04 to regenerate `coverage/coverage-summary.json` during the current run.
- Report missing or invalid coverage summary separately from threshold failures.
- Add Bats regressions for stale summary and invalid summary handling.

## Test Plan
- `npx prettier --check docs/project-management/postmortems/POSTMORTEM-2026-04-27-p0-04-coverage-false-fail.md`
- `bash -n scripts/p0-gate-check.sh scripts/lib/gate-check-common.sh`
- `npx bats tests/unit/scripts/p0-gate-check.bats`
- `npm run lint`
- `bash scripts/p0-gate-check.sh`