### PR TITLE
fix(perf): support k6 baseline summary fields

### DIFF
--- a/performance-testing-platform/docs/qa/defect-register.md
+++ b/performance-testing-platform/docs/qa/defect-register.md
@@ -10,12 +10,12 @@
 
 ## 严重度定义
 
-| 级别 | 含义 | Gate 影响 |
-|------|------|-----------|
-| **P0 / Critical** | 核心功能不可用，数据不可信 | 立即 BLOCKED，必须修复后重新执行 |
-| **P1 / High** | 重要功能降级，影响验收结论 | 标记 Blocking 时 BLOCKED；否则可 waiver |
-| **P2 / Medium** | 非核心功能异常，有合理 workaround | 不阻塞，可 waiver |
-| **P3 / Low** | 轻微问题，不影响功能或结论 | 不阻塞，记录即可 |
+| 级别              | 含义                              | Gate 影响                               |
+| ----------------- | --------------------------------- | --------------------------------------- |
+| **P0 / Critical** | 核心功能不可用，数据不可信        | 立即 BLOCKED，必须修复后重新执行        |
+| **P1 / High**     | 重要功能降级，影响验收结论        | 标记 Blocking 时 BLOCKED；否则可 waiver |
+| **P2 / Medium**   | 非核心功能异常，有合理 workaround | 不阻塞，可 waiver                       |
+| **P3 / Low**      | 轻微问题，不影响功能或结论        | 不阻塞，记录即可                        |
 
 ---
 
@@ -27,12 +27,13 @@
 
 ## 活跃缺陷登记表（Active Defects）
 
-| Defect ID | GitHub Issue | 标题摘要 | 严重度 | Blocking? | 发现日期 | 状态 | 关联 Waiver | 备注 |
-|-----------|--------------|----------|--------|-----------|----------|------|-------------|------|
-| DEF-005 | [#202](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/202) | `k6:smoke` 在 API 未启动时直接 `connection refused` | P1 / High | ⚠️ 条件性 Blocking | 2026-04-25 | 🟡 Fix in review | — | 本地已实现 wrapper 修复主路径；Issue 仍 open，待合并、关闭并补 RCA / postmortem |
-| DEF-006 | [#203](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/203) | `profile.js` 使用 `open('../../profiles/...')` 触发 k6 future warning | P2 / Medium | ❌ Non-blocking | 2026-04-25 | 🟡 Fix in review | — | 本地已改为 `import.meta.resolve()`；warning 已消失，但 Issue 尚未关闭 |
-| DEF-007 | [#204](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/204) | `BASE_URL` 与 `PORT` 组合时目标 URL 归一化不完整 | P1 / High | ✅ Blocking | 2026-04-25 | 🔴 Open | — | `BASE_URL=http://localhost PORT=3001` 时，wrapper / health / k6 目标可能不一致；需补 canonical target URL 修复 |
-| DEF-008 | [#205](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/205) | 远端 smoke 目标误触发本地 autostart | P1 / High | ✅ Blocking | 2026-04-25 | 🔴 Open | — | 非本地目标健康检查失败时仍会执行 `server.sh start single`；会污染远端 smoke 结果 |
+| Defect ID | GitHub Issue                                                                 | 标题摘要                                                              | 严重度      | Blocking?          | 发现日期   | 状态               | 关联 Waiver | 备注                                                                                                           |
+| --------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------- | ----------- | ------------------ | ---------- | ------------------ | ----------- | -------------------------------------------------------------------------------------------------------------- |
+| DEF-005   | [#202](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/202) | `k6:smoke` 在 API 未启动时直接 `connection refused`                   | P1 / High   | ⚠️ 条件性 Blocking | 2026-04-25 | 🟡 Fix in review   | —           | 本地已实现 wrapper 修复主路径；Issue 仍 open，待合并、关闭并补 RCA / postmortem                                |
+| DEF-006   | [#203](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/203) | `profile.js` 使用 `open('../../profiles/...')` 触发 k6 future warning | P2 / Medium | ❌ Non-blocking    | 2026-04-25 | 🟡 Fix in review   | —           | 本地已改为 `import.meta.resolve()`；warning 已消失，但 Issue 尚未关闭                                          |
+| DEF-007   | [#204](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/204) | `BASE_URL` 与 `PORT` 组合时目标 URL 归一化不完整                      | P1 / High   | ✅ Blocking        | 2026-04-25 | 🔴 Open            | —           | `BASE_URL=http://localhost PORT=3001` 时，wrapper / health / k6 目标可能不一致；需补 canonical target URL 修复 |
+| DEF-008   | [#205](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/205) | 远端 smoke 目标误触发本地 autostart                                   | P1 / High   | ✅ Blocking        | 2026-04-25 | 🔴 Open            | —           | 非本地目标健康检查失败时仍会执行 `server.sh start single`；会污染远端 smoke 结果                               |
+| DEF-011   | [#230](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/230) | `baseline-export.js` 不兼容当前 k6 summary `p(95)` 字段               | P1 / High   | ✅ Blocking        | 2026-04-27 | 🟡 Fix in progress | —           | 阻塞本机 `reports/baseline.json` 生成；需兼容 `http_req_duration.values['p(95)']` 与 `http_req_failed.value`   |
 
 ---
 
@@ -41,8 +42,8 @@
 > Waiver 仅用于 **P1（非核心） / P2 / P3**；P0 缺陷不得 waiver。
 
 | Waiver ID | 关联 Defect | 关联 Issue | 豁免理由 | 风险评估 | 审批人 | 审批日期 | 有效期 | 状态 |
-|-----------|-------------|------------|----------|----------|--------|----------|--------|------|
-| _(无)_ | | | | | | | | |
+| --------- | ----------- | ---------- | -------- | -------- | ------ | -------- | ------ | ---- |
+| _(无)_    |             |            |          |          |        |          |        |      |
 
 ---
 
@@ -50,34 +51,35 @@
 
 > Closed 行永不删除，供审计追溯。`DEF-001` ~ `DEF-004` 来自既有 `stage4-defect-waiver-register.md` 历史记录。
 
-| Defect ID | GitHub Issue | 标题摘要 | 严重度 | 关闭日期 | 关闭方式 | 关联 Commit / PR |
-|-----------|--------------|----------|--------|----------|----------|-------------------|
-| DEF-001 | [#192](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/192) | Grafana readiness 超时 | P1 / High | 2026-04-24 | 代码修复（healthcheck + timeout 120s） | `fix/issue-192-193` |
-| DEF-002 | [#193](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/193) | `docker-compose.yml` `version` 字段过时 | P3 / Low | 2026-04-24 | 代码修复（删除 `version` 字段） | `fix/issue-192-193` |
-| DEF-003 | [#194](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/194) | JM-GRF-01 k6 阈值与 InfluxDB 断言耦合 | P1 / High | 2026-04-24 | 修复：`--no-thresholds` + metric count 断言 | `feature/performance-testing` |
-| DEF-004 | [#195](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/195) | K6-SOAK-INT-01 named scenario 执行冲突与矛盾输出 | P1 / High | 2026-04-24 | 修复：env vars 替代 CLI 覆盖；条件化第二段 check | `feature/performance-testing` |
-| DEF-009 | [#214](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/214) | Grafana sqlite lock 导致 setup 阶段容器退出 | P1 / High | 2026-04-26 | 修复：Grafana `query_retries` / `transaction_retries` / `max_open_conn` + 统一 readiness helper | `a44aa326` |
-| DEF-010 | [#215](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/215) | Phase 6 rate limiter pipeline 因 `grep -q` SIGPIPE 误判为 FAIL | P1 / High | 2026-04-26 | 修复：k6 输出先落盘再 grep，避免 `pipefail` 捕获上游 SIGPIPE 141 | `950ceb00` |
+| Defect ID | GitHub Issue                                                                 | 标题摘要                                                       | 严重度    | 关闭日期   | 关闭方式                                                                                        | 关联 Commit / PR              |
+| --------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------- | --------- | ---------- | ----------------------------------------------------------------------------------------------- | ----------------------------- |
+| DEF-001   | [#192](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/192) | Grafana readiness 超时                                         | P1 / High | 2026-04-24 | 代码修复（healthcheck + timeout 120s）                                                          | `fix/issue-192-193`           |
+| DEF-002   | [#193](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/193) | `docker-compose.yml` `version` 字段过时                        | P3 / Low  | 2026-04-24 | 代码修复（删除 `version` 字段）                                                                 | `fix/issue-192-193`           |
+| DEF-003   | [#194](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/194) | JM-GRF-01 k6 阈值与 InfluxDB 断言耦合                          | P1 / High | 2026-04-24 | 修复：`--no-thresholds` + metric count 断言                                                     | `feature/performance-testing` |
+| DEF-004   | [#195](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/195) | K6-SOAK-INT-01 named scenario 执行冲突与矛盾输出               | P1 / High | 2026-04-24 | 修复：env vars 替代 CLI 覆盖；条件化第二段 check                                                | `feature/performance-testing` |
+| DEF-009   | [#214](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/214) | Grafana sqlite lock 导致 setup 阶段容器退出                    | P1 / High | 2026-04-26 | 修复：Grafana `query_retries` / `transaction_retries` / `max_open_conn` + 统一 readiness helper | `a44aa326`                    |
+| DEF-010   | [#215](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/215) | Phase 6 rate limiter pipeline 因 `grep -q` SIGPIPE 误判为 FAIL | P1 / High | 2026-04-26 | 修复：k6 输出先落盘再 grep，避免 `pipefail` 捕获上游 SIGPIPE 141                                | `950ceb00`                    |
 
 ---
 
 ## 历史遗留问题
 
-| Issue | 问题描述 | 关闭方式 | Commit |
-|-------|----------|----------|--------|
-| #105 | Rate limiter env binding：模块加载时读取 env var | 修复：改为 request-time check | `ce5c094b` |
-| #106 | k6 JSONL 格式与 `generate-summary.sh` 不兼容 | 修复：添加格式检测 + graceful fallback | `acf21e92` |
-| #107 | 集成测试端口冲突 | 修复：显式 stop/start + sleep 延迟 | `698d7082` |
-| #114 | Breakpoint validation 缺失 | 补充：ENT-BREAKPOINT-01/02 验收标准 | `681513bc` |
-| #116 | ENT-CONSISTENCY 与 ENT-RESILIENCE-03 验收缺失 | 补充：验收表格与验证报告 | `reports/phase6-stage4-verification-report.md` |
+| Issue | 问题描述                                         | 关闭方式                               | Commit                                         |
+| ----- | ------------------------------------------------ | -------------------------------------- | ---------------------------------------------- |
+| #105  | Rate limiter env binding：模块加载时读取 env var | 修复：改为 request-time check          | `ce5c094b`                                     |
+| #106  | k6 JSONL 格式与 `generate-summary.sh` 不兼容     | 修复：添加格式检测 + graceful fallback | `acf21e92`                                     |
+| #107  | 集成测试端口冲突                                 | 修复：显式 stop/start + sleep 延迟     | `698d7082`                                     |
+| #114  | Breakpoint validation 缺失                       | 补充：ENT-BREAKPOINT-01/02 验收标准    | `681513bc`                                     |
+| #116  | ENT-CONSISTENCY 与 ENT-RESILIENCE-03 验收缺失    | 补充：验收表格与验证报告               | `reports/phase6-stage4-verification-report.md` |
 
 ---
 
 ## 变更日志
 
-| 日期 | 变更内容 | 操作人 |
-|------|----------|--------|
-| 2026-04-26 | 登记并关闭 `DEF-010`（#215）：修正 Stage 4 register 复用 `DEF-005` 的 ID 冲突 | QA |
-| 2026-04-26 | 关闭 `DEF-009`（#214）：full integration 已通过；补充 RCA 并关闭 Issue | QA |
-| 2026-04-26 | 登记 `DEF-009`（#214）：Grafana sqlite lock 导致 integration test setup 阻塞 | QA |
-| 2026-04-25 | 新建 `docs/qa/defect-register.md`；迁移 `DEF-001` ~ `DEF-004` 历史记录；登记 `DEF-005` ~ `DEF-008`（#202 ~ #205） | QA |
+| 日期       | 变更内容                                                                                                          | 操作人 |
+| ---------- | ----------------------------------------------------------------------------------------------------------------- | ------ |
+| 2026-04-26 | 登记并关闭 `DEF-010`（#215）：修正 Stage 4 register 复用 `DEF-005` 的 ID 冲突                                     | QA     |
+| 2026-04-26 | 关闭 `DEF-009`（#214）：full integration 已通过；补充 RCA 并关闭 Issue                                            | QA     |
+| 2026-04-26 | 登记 `DEF-009`（#214）：Grafana sqlite lock 导致 integration test setup 阻塞                                      | QA     |
+| 2026-04-25 | 新建 `docs/qa/defect-register.md`；迁移 `DEF-001` ~ `DEF-004` 历史记录；登记 `DEF-005` ~ `DEF-008`（#202 ~ #205） | QA     |
+| 2026-04-27 | 登记 `DEF-011`（#230）：`baseline-export.js` 不兼容当前 k6 summary，阻塞本机 baseline 生成                        | QA     |

--- a/performance-testing-platform/docs/qa/stage4-defect-waiver-register.md
+++ b/performance-testing-platform/docs/qa/stage4-defect-waiver-register.md
@@ -27,13 +27,14 @@
 
 ## 活跃缺陷登记表（Active Defects）
 
-| Defect ID | GitHub Issue                                                                 | 标题摘要                                                               | 严重度    | Blocking?                    | 发现日期   | 状态      | 关联 Waiver | 备注                                                                                                                                             |
-| --------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------- | --------- | ---------------------------- | ---------- | --------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| DEF-001   | [#192](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/192) | Grafana readiness 超时（集成测试 setup 阶段）                          | P1 / High | ⚠️ 条件性 Blocking（若复现） | 2026-04-23 | ✅ Closed | —           | 修复：grafana 添加 healthcheck；timeout 60→120s                                                                                                  |
-| DEF-002   | [#193](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/193) | `docker-compose.yml` `version` 字段过时警告                            | P3 / Low  | ❌ Non-blocking              | 2026-04-23 | ✅ Closed | WAV-001     | 修复：删除顶层 `version: '3.8'` 字段                                                                                                             |
-| DEF-003   | [#194](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/194) | JM-GRF-01 失败（Grafana 集成阶段 k6 http_req_failed 86.66%）           | P1 / High | ✅ Blocking                  | 2026-04-23 | 🟢 Fixed  | —           | 根因：k6 smoke 阈值与 Grafana 集成断言耦合。修复：加 `--no-thresholds` + InfluxDB 指标计数断言。Commit: _(本次)_                                 |
-| DEF-004   | [#195](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/195) | K6-SOAK-INT-01 结果矛盾（metrics not written vs custom metrics found） | P1 / High | ✅ Blocking                  | 2026-04-23 | 🟢 Fixed  | —           | 根因：`--vus`/`--duration` 覆盖 named scenario，找不到 `default` 导出。修复：改用 env vars 配置时长；第二段 check 改为条件执行。Commit: _(本次)_ |
-| DEF-005   | [#215](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/215) | Phase 6 rate limiter pipeline 因 `grep -q` SIGPIPE 误判为 FAIL          | P1 / High | ✅ Blocking                  | 2026-04-26 | 🟢 Fixed  | —           | 根因：`tests/integration/phases/phase-6-rate-limiter.sh` 在 `set -o pipefail` 下使用 `npm ... 2>&1 \| grep -q "rate limited (429)"`，`grep -q` 命中后提前退出导致上游 SIGPIPE，pipeline 返回 141。修复：改为先把 k6 输出落盘再 grep，按业务信号 `rate limited (429)` 判 PASS，npm 退出码非零仅记录 WARN。Commit: _(本次)_ |
+| Defect ID | GitHub Issue                                                                 | 标题摘要                                                               | 严重度    | Blocking?                    | 发现日期   | 状态               | 关联 Waiver | 备注                                                                                                                                                                                                                                                                                                                      |
+| --------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------- | --------- | ---------------------------- | ---------- | ------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| DEF-001   | [#192](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/192) | Grafana readiness 超时（集成测试 setup 阶段）                          | P1 / High | ⚠️ 条件性 Blocking（若复现） | 2026-04-23 | ✅ Closed          | —           | 修复：grafana 添加 healthcheck；timeout 60→120s                                                                                                                                                                                                                                                                           |
+| DEF-002   | [#193](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/193) | `docker-compose.yml` `version` 字段过时警告                            | P3 / Low  | ❌ Non-blocking              | 2026-04-23 | ✅ Closed          | WAV-001     | 修复：删除顶层 `version: '3.8'` 字段                                                                                                                                                                                                                                                                                      |
+| DEF-003   | [#194](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/194) | JM-GRF-01 失败（Grafana 集成阶段 k6 http_req_failed 86.66%）           | P1 / High | ✅ Blocking                  | 2026-04-23 | 🟢 Fixed           | —           | 根因：k6 smoke 阈值与 Grafana 集成断言耦合。修复：加 `--no-thresholds` + InfluxDB 指标计数断言。Commit: _(本次)_                                                                                                                                                                                                          |
+| DEF-004   | [#195](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/195) | K6-SOAK-INT-01 结果矛盾（metrics not written vs custom metrics found） | P1 / High | ✅ Blocking                  | 2026-04-23 | 🟢 Fixed           | —           | 根因：`--vus`/`--duration` 覆盖 named scenario，找不到 `default` 导出。修复：改用 env vars 配置时长；第二段 check 改为条件执行。Commit: _(本次)_                                                                                                                                                                          |
+| DEF-005   | [#215](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/215) | Phase 6 rate limiter pipeline 因 `grep -q` SIGPIPE 误判为 FAIL         | P1 / High | ✅ Blocking                  | 2026-04-26 | 🟢 Fixed           | —           | 根因：`tests/integration/phases/phase-6-rate-limiter.sh` 在 `set -o pipefail` 下使用 `npm ... 2>&1 \| grep -q "rate limited (429)"`，`grep -q` 命中后提前退出导致上游 SIGPIPE，pipeline 返回 141。修复：改为先把 k6 输出落盘再 grep，按业务信号 `rate limited (429)` 判 PASS，npm 退出码非零仅记录 WARN。Commit: _(本次)_ |
+| DEF-011   | [#230](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/230) | `baseline-export.js` 不兼容当前 k6 summary `p(95)` 字段                | P1 / High | ✅ Blocking                  | 2026-04-27 | 🟡 Fix in progress | —           | 阻塞 `npm run baseline:export`，导致本机 `reports/baseline.json` 无法生成。修复方向：兼容 k6 summary `values['p(95)']`、`http_req_failed.value` 与 `http_reqs.count`                                                                                                                                                      |
 
 ---
 
@@ -42,8 +43,8 @@
 > Waiver 仅用于 **P2/P3** 级别，或经过充分论证的 P1 非核心缺陷。  
 > P0 缺陷**不得** waiver。
 
-| Waiver ID | 关联 Defect | 关联 Issue | 豁免理由                                                                                          | 风险评估         | 审批人 | 审批日期   | 有效期 | 状态                    |
-| --------- | ----------- | ---------- | ------------------------------------------------------------------------------------------------- | ---------------- | ------ | ---------- | ------ | ----------------------- |
+| Waiver ID | 关联 Defect | 关联 Issue | 豁免理由                                                                                            | 风险评估         | 审批人 | 审批日期   | 有效期 | 状态                    |
+| --------- | ----------- | ---------- | --------------------------------------------------------------------------------------------------- | ---------------- | ------ | ---------- | ------ | ----------------------- |
 | WAV-001   | DEF-002     | #193       | `version` 字段为废弃 warning，Docker Compose 已忽略该字段，容器行为不受影响；已随 #193 修复直接删除 | 极低：无功能影响 | QA     | 2026-04-24 | —      | ✅ 已关闭（随修复失效） |
 
 ---
@@ -52,13 +53,13 @@
 
 > 关闭后保留记录，供审计追溯。
 
-| Defect ID | GitHub Issue                                                                 | 标题摘要                                                 | 严重度    | 关闭日期   | 关闭方式                                                     | 关联 Commit                        |
-| --------- | ---------------------------------------------------------------------------- | -------------------------------------------------------- | --------- | ---------- | ------------------------------------------------------------ | ---------------------------------- |
-| DEF-001   | [#192](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/192) | Grafana readiness 超时                                   | P1 / High | 2026-04-24 | 代码修复（healthcheck + timeout 120s）                       | fix/issue-192-193                  |
-| DEF-002   | [#193](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/193) | docker-compose.yml version 字段过时                      | P3 / Low  | 2026-04-24 | 代码修复（删除 version 字段）                                | fix/issue-192-193                  |
-| DEF-003   | [#194](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/194) | JM-GRF-01 k6 阈值与 InfluxDB 断言耦合                    | P1        | 2026-04-24 | 修复：`--no-thresholds` + metric count 断言                  | _(见 feature/performance-testing)_ |
-| DEF-004   | [#195](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/195) | K6-SOAK-INT-01 named scenario exec 函数找不到 + 矛盾输出 | P1        | 2026-04-24 | 修复：env vars 替代 `--vus`/`--duration`；条件化第二段 check | _(见 feature/performance-testing)_ |
-| DEF-010   | [#215](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/215) | Phase 6 rate limiter pipeline 因 `grep -q` SIGPIPE 误判为 FAIL | P1 / High | 2026-04-26 | 修复：k6 输出先落盘再 grep，避免 `pipefail` 捕获上游 SIGPIPE 141 | `950ceb00` |
+| Defect ID | GitHub Issue                                                                 | 标题摘要                                                       | 严重度    | 关闭日期   | 关闭方式                                                         | 关联 Commit                        |
+| --------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------- | --------- | ---------- | ---------------------------------------------------------------- | ---------------------------------- |
+| DEF-001   | [#192](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/192) | Grafana readiness 超时                                         | P1 / High | 2026-04-24 | 代码修复（healthcheck + timeout 120s）                           | fix/issue-192-193                  |
+| DEF-002   | [#193](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/193) | docker-compose.yml version 字段过时                            | P3 / Low  | 2026-04-24 | 代码修复（删除 version 字段）                                    | fix/issue-192-193                  |
+| DEF-003   | [#194](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/194) | JM-GRF-01 k6 阈值与 InfluxDB 断言耦合                          | P1        | 2026-04-24 | 修复：`--no-thresholds` + metric count 断言                      | _(见 feature/performance-testing)_ |
+| DEF-004   | [#195](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/195) | K6-SOAK-INT-01 named scenario exec 函数找不到 + 矛盾输出       | P1        | 2026-04-24 | 修复：env vars 替代 `--vus`/`--duration`；条件化第二段 check     | _(见 feature/performance-testing)_ |
+| DEF-010   | [#215](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/215) | Phase 6 rate limiter pipeline 因 `grep -q` SIGPIPE 误判为 FAIL | P1 / High | 2026-04-26 | 修复：k6 输出先落盘再 grep，避免 `pipefail` 捕获上游 SIGPIPE 141 | `950ceb00`                         |
 
 ---
 
@@ -76,10 +77,11 @@
 
 ## 变更日志
 
-| 日期       | 变更内容                                                                             | 操作人 |
-| ---------- | ------------------------------------------------------------------------------------ | ------ |
-| 2026-04-24 | 初始建表；登记 DEF-001~004（源自 Phase 7 集成测试运行 #192~#195）；创建 WAV-001 草稿 | QA     |
-| 2026-04-24 | DEF-001/DEF-002 标为 Closed（代码已修复）；WAV-001 关闭；更新 Closed 历史表          | QA     |
-| 2026-04-24 | 修复 DEF-003/DEF-004，状态改为 Fixed；同步至 Closed Defects 历史                     | QA     |
+| 日期       | 变更内容                                                                               | 操作人 |
+| ---------- | -------------------------------------------------------------------------------------- | ------ |
+| 2026-04-24 | 初始建表；登记 DEF-001~004（源自 Phase 7 集成测试运行 #192~#195）；创建 WAV-001 草稿   | QA     |
+| 2026-04-24 | DEF-001/DEF-002 标为 Closed（代码已修复）；WAV-001 关闭；更新 Closed 历史表            | QA     |
+| 2026-04-24 | 修复 DEF-003/DEF-004，状态改为 Fixed；同步至 Closed Defects 历史                       | QA     |
 | 2026-04-24 | DEF-001/DEF-002 标为 Closed（代码已修复，#192/#193）；WAV-001 关闭；更新 Closed 历史表 | QA     |
-| 2026-04-26 | 将 #215 从冲突的 `DEF-005` 改为 `DEF-010`，并移入 Closed Defects 历史 | QA     |
+| 2026-04-26 | 将 #215 从冲突的 `DEF-005` 改为 `DEF-010`，并移入 Closed Defects 历史                  | QA     |
+| 2026-04-27 | 登记 DEF-011（#230）：`baseline-export.js` 不兼容当前 k6 summary，阻塞 baseline 生成   | QA     |

--- a/performance-testing-platform/scripts/analysis/baseline-export.js
+++ b/performance-testing-platform/scripts/analysis/baseline-export.js
@@ -28,15 +28,21 @@ try {
 
   // Extract k6 metrics
   const metrics = summary.metrics || {};
-  const duration = metrics.http_req_duration?.values || {};
-  const p95 = duration.p('0.95') || duration['p(95)'] || 500;
+  const durationMetric = metrics.http_req_duration || {};
+  const duration = durationMetric.values || durationMetric;
+  const p95 = duration['p(95)'] || duration['p(0.95)'] || 500;
 
   const checks = summary.checks || [];
   const totalChecks = checks.length;
   const failedChecks = checks.filter((c) => !c.passes).length;
-  const errorRate = totalChecks > 0 ? failedChecks / totalChecks : 0.01;
+  const errorRate =
+    typeof metrics.http_req_failed?.value === 'number'
+      ? metrics.http_req_failed.value
+      : totalChecks > 0
+        ? failedChecks / totalChecks
+        : 0.01;
 
-  const http_reqs = metrics.http_reqs?.value || 0;
+  const http_reqs = metrics.http_reqs?.count || metrics.http_reqs?.value || 0;
   const testDuration = (summary.state?.testRunDurationMs || 60000) / 1000; // seconds
   const throughput_rps = testDuration > 0 ? http_reqs / testDuration : 50;
 

--- a/performance-testing-platform/tests/unit/scripts/baseline-export.test.js
+++ b/performance-testing-platform/tests/unit/scripts/baseline-export.test.js
@@ -1,0 +1,95 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const PROJECT_ROOT = path.join(__dirname, '../../..');
+const SCRIPT = path.join(PROJECT_ROOT, 'scripts/analysis/baseline-export.js');
+
+describe('baseline-export.js', () => {
+  test('exports baseline from current k6 summary values fields', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'baseline-export-'));
+    const summaryFile = path.join(tempDir, 'summary.json');
+    const outputFile = path.join(tempDir, 'baseline.json');
+
+    fs.writeFileSync(
+      summaryFile,
+      JSON.stringify({
+        metrics: {
+          http_req_duration: {
+            values: {
+              'p(95)': 3.085,
+              avg: 1.43,
+            },
+          },
+          http_req_failed: {
+            value: 0,
+          },
+          http_reqs: {
+            count: 900,
+            rate: 14.92,
+          },
+        },
+        state: {
+          testRunDurationMs: 60313,
+        },
+      })
+    );
+
+    const result = spawnSync('node', [SCRIPT, summaryFile, outputFile], {
+      cwd: PROJECT_ROOT,
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    const baseline = JSON.parse(fs.readFileSync(outputFile, 'utf8'));
+    expect(baseline).toMatchObject({
+      p95_ms: 3,
+      error_rate: 0,
+      throughput_rps: 14.9,
+      run_id: 'local',
+    });
+  });
+
+  test('exports baseline from current k6 summary top-level metric fields', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'baseline-export-'));
+    const summaryFile = path.join(tempDir, 'summary.json');
+    const outputFile = path.join(tempDir, 'baseline.json');
+
+    fs.writeFileSync(
+      summaryFile,
+      JSON.stringify({
+        metrics: {
+          http_req_duration: {
+            'p(95)': 3.69,
+            avg: 5.81,
+          },
+          http_req_failed: {
+            value: 0,
+          },
+          http_reqs: {
+            count: 885,
+            rate: 14.72,
+          },
+        },
+        state: {
+          testRunDurationMs: 60100,
+        },
+      })
+    );
+
+    const result = spawnSync('node', [SCRIPT, summaryFile, outputFile], {
+      cwd: PROJECT_ROOT,
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    const baseline = JSON.parse(fs.readFileSync(outputFile, 'utf8'));
+    expect(baseline).toMatchObject({
+      p95_ms: 4,
+      error_rate: 0,
+      throughput_rps: 14.7,
+      run_id: 'local',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fix `baseline-export.js` to read current k6 summary fields such as `http_req_duration['p(95)']`, `http_req_failed.value`, and `http_reqs.count`.
- Add unit coverage for both `values` and top-level k6 metric summary formats.
- Register DEF-011 / #230 in `performance-testing-platform/docs/qa` defect tracking.

## Test Plan
- `npx prettier --check scripts/analysis/baseline-export.js tests/unit/scripts/baseline-export.test.js docs/qa/defect-register.md docs/qa/stage4-defect-waiver-register.md`
- `npx jest tests/unit/scripts/baseline-export.test.js tests/unit/utils/baseline.test.js --runInBand`
- `npm run lint`
- `npm run k6:smoke -- --summary-export summary.json`
- `npm run baseline:export`

## Local baseline

Generated locally under ignored runtime artifacts:

```json
{
  "p95_ms": 4,
  "error_rate": 0,
  "throughput_rps": 14.8,
  "run_id": "local"
}
```

Fixes #230