### PR TITLE
feat(pre-push): add Markdown link check gate (PDEF-005 prevention)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -93,6 +93,23 @@ if [ -x "$GUARD" ] && [ -n "$GUARD_HEAD" ]; then
     fi
 fi
 
+# --- Markdown 断链检查（所有变更的 .md 文件）---
+MD_LINK_SCRIPT="$REPO_ROOT/scripts/check-markdown-links.sh"
+if [ -x "$MD_LINK_SCRIPT" ] && [ -n "$GUARD_HEAD" ] && [ -n "$GUARD_BASE" ]; then
+    MD_LIST=$(git diff --name-only "${GUARD_BASE}..${GUARD_HEAD}" 2>/dev/null | grep '\.md$' || true)
+    if [ -n "$MD_LIST" ]; then
+        # shellcheck disable=SC2086
+        if ! "$MD_LINK_SCRIPT" $MD_LIST; then
+            echo ""
+            echo "✖ Markdown 断链 — 请修正相对路径后重新 push"
+            echo "   绕过（不推荐）：git push --no-verify"
+            exit 1
+        fi
+    else
+        echo "→ Markdown links: no .md changes, skip"
+    fi
+fi
+
 # 本次 push 未涉及 performance-testing-platform，跳过质量门控
 if [ "$PERF_CHANGED" -eq 0 ]; then
     exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,12 @@ All workflows are in root `.github/workflows/` (GitHub ignores subdirectory work
 
 ## Pre-commit Checklist
 
+### 通用（含 Markdown 文件变更时）
+
+```bash
+bash scripts/check-markdown-links.sh   # 检查变更的 .md 文件相对路径
+```
+
 ### Python Projects
 
 ```bash

--- a/scripts/check-markdown-links.sh
+++ b/scripts/check-markdown-links.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# check-markdown-links.sh — 本地 Markdown 断链检查（镜像 repo-meta-ci.yml 逻辑）
+#
+# 用法：
+#   bash scripts/check-markdown-links.sh [file1.md file2.md ...]
+#   # 无参数 → 自动检测 git diff 中变更的 .md 文件
+#
+# 退出码：0 = 全部通过；1 = 有断链；2 = python3 不可用（warning，不阻塞）
+#
+# PDEF-005 改进项 AI-1：将 CI 断链检查能力引入本地，消除"仅 CI 发现"盲区
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# --- 收集待检查的 .md 文件 ---
+if [ "$#" -gt 0 ]; then
+    MD_FILES=("$@")
+else
+    # 无参数：从 git diff 取变更的 .md 文件
+    mapfile -t MD_FILES < <(
+        git diff --name-only HEAD 2>/dev/null \
+        | grep '\.md$' \
+        || true
+    )
+    # fallback：staged 文件
+    if [ "${#MD_FILES[@]}" -eq 0 ]; then
+        mapfile -t MD_FILES < <(
+            git diff --cached --name-only 2>/dev/null \
+            | grep '\.md$' \
+            || true
+        )
+    fi
+fi
+
+# 过滤不存在的文件，转为绝对路径
+EXISTING=()
+for f in "${MD_FILES[@]:-}"; do
+    [ -z "$f" ] && continue
+    abs="$REPO_ROOT/$f"
+    [ -f "$abs" ] && EXISTING+=("$abs")
+done
+
+if [ "${#EXISTING[@]}" -eq 0 ]; then
+    echo "→ Markdown links: no .md files to check, skip"
+    exit 0
+fi
+
+echo "→ Markdown links: checking ${#EXISTING[@]} file(s)"
+
+# python3 可用性检查（降级为 warning，不阻塞）
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "⚠  python3 not found — skip Markdown link check (CI will catch issues)"
+    exit 2
+fi
+
+# --- 运行与 repo-meta-ci.yml 完全相同的 Python 逻辑 ---
+python3 - "$REPO_ROOT" "${EXISTING[@]}" <<'PY'
+import pathlib
+import re
+import sys
+from urllib.parse import unquote
+
+repo_root = pathlib.Path(sys.argv[1]).resolve()
+files = [pathlib.Path(p).resolve() for p in sys.argv[2:]]
+pattern = re.compile(r'!?\[[^\]]*\]\(([^)]+)\)')
+
+failures = []
+for markdown_file in files:
+    if not markdown_file.exists():
+        continue
+    text = markdown_file.read_text(encoding="utf-8")
+    for raw_target in pattern.findall(text):
+        target = raw_target.strip()
+        if not target or target.startswith(("#", "http://", "https://", "mailto:")):
+            continue
+        if target.startswith("<") and target.endswith(">"):
+            target = target[1:-1]
+        target = target.split()[0]
+        target = unquote(target.split("#", 1)[0])
+        if not target:
+            continue
+
+        resolved = (markdown_file.parent / target).resolve()
+        try:
+            resolved.relative_to(repo_root)
+        except ValueError:
+            failures.append(f"{markdown_file.relative_to(repo_root)}: {raw_target} (outside repository)")
+            continue
+
+        if not resolved.exists():
+            failures.append(f"{markdown_file.relative_to(repo_root)}: {raw_target}")
+
+if failures:
+    print("Broken Markdown links detected:")
+    for f in failures:
+        print(f" - {f}")
+    sys.exit(1)
+
+print(f"✔ Markdown links OK ({len(files)} file(s) checked)")
+PY


### PR DESCRIPTION
## Summary

- **scripts/check-markdown-links.sh** (new): mirrors `repo-meta-ci.yml` Python broken-link logic for local use; accepts file args or auto-detects `git diff` changed `.md` files
- **.husky/pre-push**: inserts Markdown link check after Commit Guard, before performance-testing-platform gates; covers all branches
- **CLAUDE.md**: adds universal Pre-commit Checklist entry for `bash scripts/check-markdown-links.sh`

## Motivation

PDEF-005 root cause B: no local equivalent of `repo-meta-ci.yml`'s Python link checker — broken `.md` links were only caught by CI. Q2 had 3 occurrences (PDEF-001 / PDEF-004 / PDEF-005). This PR closes the structural gap.

RCA: `docs/project-management/postmortems/RCA-2026-05-26-PDEF-005-rca-broken-links.md`

## Test plan

- [x] `bash scripts/check-markdown-links.sh _test_.md` with broken link → exit 1, prints path
- [x] `bash scripts/check-markdown-links.sh _test_.md` with valid link → exit 0, ✔ OK
- [x] no `.md` args → `no .md files to check, skip`, exit 0
- [x] auto-detect mode (no args) → picks up `git diff` changed `.md` files
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)