### PR TITLE
fix(perf): add dependabot/ to branch whitelist in bats

### DIFF
--- a/performance-testing-platform/tests/unit/scripts/stage4-selftest-fast.bats
+++ b/performance-testing-platform/tests/unit/scripts/stage4-selftest-fast.bats
@@ -141,7 +141,7 @@ teardown() {
   if [ -z "$branch" ]; then
     branch="${GITHUB_HEAD_REF:-}"
   fi
-  echo "$branch" | grep -qE "^(main|feature/|fix/|docs/|copilot/|hotfix/)"
+  echo "$branch" | grep -qE "^(main|feature/|fix/|docs/|copilot/|hotfix/|dependabot/)"
 }
 
 @test "9.2: 最近 20 条提交应包含 conventional commits" {


### PR DESCRIPTION
## Summary

- 在 `stage4-selftest-fast.bats` test 9.1 的分支白名单正则中新增 `dependabot/` 前缀
- 修复所有跑 Performance Testing CI 的 Dependabot PR 在 Shell Tests (Fast) 阶段失败的问题

**受影响 PRs（合并后 CI 将重新通过）：**
#330 #327 #323 #316 #311 #297

**根本原因：** `dependabot/npm_and_yarn/...` 和 `dependabot/docker/...` 分支不匹配 `^(main|feature/|fix/|docs/|copilot/|hotfix/)` 正则，导致 test 13 必然失败。

## Test plan

- [x] 本地 BATS fast 14/14 通过（含 test 9.1）
- [x] pre-push hook 全部质量门控通过
- [ ] CI `Performance Testing / Shell Tests (Fast)` 绿灯

🤖 Generated with [Claude Code](https://claude.com/claude-code)