### PR TITLE
fix(ai-testing): repair GEval API compat and monkeypatch tests

### DIFF
--- a/ai-testing-platform/src/llm_evaluator/bias.py
+++ b/ai-testing-platform/src/llm_evaluator/bias.py
@@ -10,11 +10,13 @@ class BiasEvaluator(BaseLLMEvaluator):
             raise LLMEvaluatorError("OPENAI_API_KEY not set; cannot run LLM evaluation")
 
         model = self._get_model()
+        ctx = io.context or []
         test_case = LLMTestCase(
             input=io.input,
             actual_output=io.actual_output,
             expected_output=io.expected_output,
-            context=io.context or [],
+            context=ctx,
+            retrieval_context=ctx,
         )
 
         results = []

--- a/ai-testing-platform/src/llm_evaluator/evaluator.py
+++ b/ai-testing-platform/src/llm_evaluator/evaluator.py
@@ -3,6 +3,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Optional
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 
 class LLMEvaluatorError(Exception):
     pass

--- a/ai-testing-platform/src/llm_evaluator/hallucination.py
+++ b/ai-testing-platform/src/llm_evaluator/hallucination.py
@@ -10,11 +10,13 @@ class HallucinationEvaluator(BaseLLMEvaluator):
             raise LLMEvaluatorError("OPENAI_API_KEY not set; cannot run LLM evaluation")
 
         model = self._get_model()
+        ctx = io.context or []
         test_case = LLMTestCase(
             input=io.input,
             actual_output=io.actual_output,
             expected_output=io.expected_output,
-            context=io.context or [],
+            context=ctx,
+            retrieval_context=ctx,
         )
 
         results = []

--- a/ai-testing-platform/src/llm_evaluator/quality.py
+++ b/ai-testing-platform/src/llm_evaluator/quality.py
@@ -1,5 +1,5 @@
 from deepeval.metrics import AnswerRelevancyMetric, ContextualPrecisionMetric, GEval
-from deepeval.test_case import LLMTestCase
+from deepeval.test_case import LLMTestCase, SingleTurnParams
 
 from .evaluator import LLMIO, BaseLLMEvaluator, LLMEvaluatorError, MetricResult
 
@@ -10,19 +10,26 @@ class QualityEvaluator(BaseLLMEvaluator):
             raise LLMEvaluatorError("OPENAI_API_KEY not set; cannot run LLM evaluation")
 
         model = self._get_model()
+        ctx = io.context or []
         test_case = LLMTestCase(
             input=io.input,
             actual_output=io.actual_output,
             expected_output=io.expected_output,
-            context=io.context or [],
+            context=ctx,
+            retrieval_context=ctx,
         )
 
         results = []
+
+        g_eval_params = [SingleTurnParams.INPUT, SingleTurnParams.ACTUAL_OUTPUT]
+        if io.expected_output is not None:
+            g_eval_params.append(SingleTurnParams.EXPECTED_OUTPUT)
 
         g_eval = GEval(
             name="Correctness",
             criteria="Determine if the actual output is correct based on the expected output",
             evaluation_steps=["Check if output matches the expected answer"],
+            evaluation_params=g_eval_params,
             model=model,
         )
         g_eval.measure(test_case)

--- a/ai-testing-platform/tests/integration/conftest.py
+++ b/ai-testing-platform/tests/integration/conftest.py
@@ -1,0 +1,1 @@
+from tests.test_llm_evaluator.conftest import *  # noqa: F401, F403

--- a/ai-testing-platform/tests/test_llm_evaluator/test_bias.py
+++ b/ai-testing-platform/tests/test_llm_evaluator/test_bias.py
@@ -6,27 +6,31 @@ from src.llm_evaluator import LLMIO, LLMEvaluatorError
 
 
 class TestBiasUnit:
-    def test_import_bias_evaluator(self):
+    def test_import_bias_evaluator(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         from src.llm_evaluator import BiasEvaluator
 
         e = BiasEvaluator()
         assert e is not None
 
-    def test_evaluate_raises_without_api_key(self, biased_io):
+    def test_evaluate_raises_without_api_key(self, biased_io, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         from src.llm_evaluator import BiasEvaluator
 
         e = BiasEvaluator()
         with pytest.raises(LLMEvaluatorError, match="OPENAI_API_KEY not set"):
             e.evaluate(biased_io)
 
-    def test_evaluate_raises_on_empty_input(self):
+    def test_evaluate_raises_on_empty_input(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         from src.llm_evaluator import BiasEvaluator
 
         e = BiasEvaluator()
         with pytest.raises(LLMEvaluatorError, match="OPENAI_API_KEY not set"):
             e.evaluate(LLMIO(input="", actual_output=""))
 
-    def test_evaluate_raises_on_short_input(self):
+    def test_evaluate_raises_on_short_input(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         from src.llm_evaluator import BiasEvaluator
 
         e = BiasEvaluator()

--- a/ai-testing-platform/tests/test_llm_evaluator/test_hallucination.py
+++ b/ai-testing-platform/tests/test_llm_evaluator/test_hallucination.py
@@ -6,27 +6,31 @@ from src.llm_evaluator import LLMIO, LLMEvaluatorError
 
 
 class TestHallucinationUnit:
-    def test_import_hallucination_evaluator(self):
+    def test_import_hallucination_evaluator(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         from src.llm_evaluator import HallucinationEvaluator
 
         e = HallucinationEvaluator()
         assert e is not None
 
-    def test_evaluate_raises_without_api_key(self, faithful_io):
+    def test_evaluate_raises_without_api_key(self, faithful_io, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         from src.llm_evaluator import HallucinationEvaluator
 
         e = HallucinationEvaluator()
         with pytest.raises(LLMEvaluatorError, match="OPENAI_API_KEY not set"):
             e.evaluate(faithful_io)
 
-    def test_evaluate_raises_without_context(self):
+    def test_evaluate_raises_without_context(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         from src.llm_evaluator import HallucinationEvaluator
 
         e = HallucinationEvaluator()
         with pytest.raises(LLMEvaluatorError, match="OPENAI_API_KEY not set"):
             e.evaluate(LLMIO(input="q", actual_output="a"))
 
-    def test_evaluate_raises_on_empty_output(self):
+    def test_evaluate_raises_on_empty_output(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         from src.llm_evaluator import HallucinationEvaluator
 
         e = HallucinationEvaluator()

--- a/ai-testing-platform/tests/test_llm_evaluator/test_quality.py
+++ b/ai-testing-platform/tests/test_llm_evaluator/test_quality.py
@@ -6,20 +6,23 @@ from src.llm_evaluator import LLMIO, LLMEvaluatorError
 
 
 class TestQualityUnit:
-    def test_import_quality_evaluator(self):
+    def test_import_quality_evaluator(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         from src.llm_evaluator import QualityEvaluator
 
         evaluator = QualityEvaluator()
         assert evaluator is not None
 
-    def test_evaluate_raises_without_api_key(self, sample_llm_io):
+    def test_evaluate_raises_without_api_key(self, sample_llm_io, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         from src.llm_evaluator import QualityEvaluator
 
         evaluator = QualityEvaluator()
         with pytest.raises(LLMEvaluatorError, match="OPENAI_API_KEY not set"):
             evaluator.evaluate(sample_llm_io)
 
-    def test_evaluate_raises_on_empty_input(self):
+    def test_evaluate_raises_on_empty_input(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         from src.llm_evaluator import QualityEvaluator
 
         evaluator = QualityEvaluator()


### PR DESCRIPTION
## Bug fixes found during self-testing

### Issues Fixed

| File | Issue | Fix |
|------|-------|-----|
| quality.py | GEval requires `evaluation_params` (SingleTurnParams enum) in DeepEval 4.1.0 | Added with conditional EXPECTED_OUTPUT |
| quality/hallucination/bias | LLMTestCase missing `retrieval_context` for FaithfulnessMetric | Added alongside `context` |
| evaluator.py | .env file not auto-loaded | Added `load_dotenv()` |
| test_quality/hallucination/bias | Tests fail when .env has real API key | Added monkeypatch.delenv() |
| integration tests | Conftest fixtures not found | Added tests/integration/conftest.py |

### Verification
- 27 unit tests PASS
- 9 integration tests PASS (DeepSeek API, 103s)
- 15 LLM tests PASS (43s/module)
- ruff + flake8 clean