### PR TITLE
docs: complete PREQ-006 req management (Phase 1-4)

### DIFF
--- a/cicd-demo/docs/requirements/REQUIREMENTS.md
+++ b/cicd-demo/docs/requirements/REQUIREMENTS.md
@@ -1,0 +1,29 @@
+# CICD Demo — Requirements
+
+## 功能需求
+
+| ID | 描述 | 优先级 |
+|----|------|--------|
+| FR-CICD-001 | Terraform IaC（S3, DynamoDB, 3 环境） | P0 |
+| FR-CICD-002 | Kubernetes 编排（k3d, 3 节点） | P0 |
+| FR-CICD-003 | ArgoCD GitOps（dev 自动/staging 手动同步） | P0 |
+| FR-CICD-004 | Helm Charts 版本化部署 | P0 |
+| FR-CICD-005 | Trivy 4 层安全扫描（fs/Docker/IaC/dep） | P0 |
+| FR-CICD-006 | Prometheus + Grafana 监控（14 面板） | P1 |
+| FR-CICD-007 | AlertManager + Slack 告警 | P1 |
+| FR-CICD-008 | npm audit 依赖检查 | P1 |
+| FR-CICD-009 | Cypress E2E 测试（16 测试） | P1 |
+| FR-CICD-010 | Newman API 测试（18 断言） | P1 |
+| FR-CICD-011 | GitHub Actions PR 门禁 + 部署流水线 | P0 |
+| FR-CICD-012 | Docker Compose 容器化测试执行 | P1 |
+| FR-CICD-013 | Pushgateway 构建/测试/部署指标 | P2 |
+| FR-CICD-014 | Loki + Promtail 日志聚合 | P2 |
+| FR-CICD-015 | Localstack 本地 AWS 模拟 | P2 |
+
+## 非功能需求
+
+| ID | 类别 | 要求 |
+|----|------|------|
+| NFR-CICD-001 | CI | PR gate + deploy pipeline + Terraform CI |
+| NFR-CICD-002 | 安全 | Trivy SARIF → GitHub Security |
+| NFR-CICD-003 | 恢复 | ArgoCD 自愈功能 |

--- a/docs/requirements/how-to-use.md
+++ b/docs/requirements/how-to-use.md
@@ -108,6 +108,23 @@
 
 ---
 
+---
+
+## Issue ↔ 需求同步规范
+
+需求台账（`req-register.md`）与 GitHub Issue 之间必须保持双向可追溯：
+
+| 事件 | 操作 | 时限 |
+|------|------|------|
+| 创建 Issue | 在 `req-register.md` 新增一行，填写 REQ-ID + Issue 链接 | 24h |
+| Issue 状态变更 | 同步更新台账状态列（Proposed / Refined / In Development / Verified / Closed） | 24h |
+| PR 合并 | 如果 PR 关联需求，更新台账状态并补充关联 PR 编号 | 合并后 24h |
+| 季度审计 | 扫描所有 Open Issue → 台账中是否有对应行，缺失则补录 | 每季度末 |
+
+**示例**：Issue #437（PREQ-006）状态为 In Development → 台账对应行状态为 In Development。
+
+---
+
 ## 常见问题
 
 **Q：每个需求都要建 GitHub Issue 吗？**

--- a/docs/requirements/req-register.md
+++ b/docs/requirements/req-register.md
@@ -35,6 +35,8 @@
 | PREQ-008 | — | 缺陷管理系统覆盖：台账 + Waiver 政策 + Flaky 分级 + 依赖风险 SLA | 仓库级 / QA 体系 | DEMO | P1 | 2026-05-26 | Verified | — |
 | PREQ-012 | [#431](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/431) | commit-guard.yml 无 path filter | 仓库级 / CI 规范 | NFR | P2 | 2026-07-13 | Refined | — |
 | PREQ-014 | [#433](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/433) | Dependabot 缺少 Python 生态（7 个 pip） | 仓库级 / 安全 | NFR | P1 | 2026-07-13 | Refined | — |
+| PREQ-016 | [#42](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/42) | Alibaba Cloud ECS + K3s 真实部署 | cicd-demo | FR | P2 | 2026-07-17 | Proposed | — |
+| PREQ-017 | [#18](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/18) | Mobile Testing Demo (Appium/Detox) | 新项目 | FR | P2 | 2026-07-17 | Proposed | — |
 
 ---
 
@@ -70,14 +72,17 @@
 
 | 项目 | 需求文档位置 | 当前活跃数 | 关联 RTM | 最近更新 |
 |------|------------|-----------|---------|---------|
-| cicd-demo | [RTM.md](RTM.md)（含 cicd-demo 全量需求）| 24（FR: 16 / NFR: 8） | [RTM.md](RTM.md) | 2026-05-24 |
-| performance-testing-platform | _(按需初始化，复制 [模板](req-template.md))_ | — | — | — |
-| api-testing-demo | _(按需初始化)_ | — | — | — |
-| k8s-auto-testing-platform | _(按需初始化)_ | — | — | — |
-| security-testing-demo | _(按需初始化)_ | — | — | — |
-| sid-iam-testing-platform | _(按需初始化)_ | — | — | — |
-| microservice-testing-platform | _(按需初始化)_ | — | — | — |
-| ai-testing-platform | _(按需初始化)_ | — | — | — |
+| cicd-demo | [REQUIREMENTS.md](../../cicd-demo/docs/requirements/REQUIREMENTS.md) | — | — | 2026-07-17 |
+| performance-testing-platform | [requirements.md](../../performance-testing-platform/docs/project-management/requirements.md) | — | — | 2026-07-17 |
+| api-testing-demo | [REQUIREMENTS.md](../../api-testing-demo/docs/project-management/REQUIREMENTS.md) | — | — | 2026-07-17 |
+| k8s-auto-testing-platform | [REQUIREMENTS.md](../../k8s-auto-testing-platform/docs/requirements/REQUIREMENTS.md) | — | — | 2026-07-17 |
+| security-testing-demo | [REQUIREMENTS.md](../../security-testing-demo/docs/requirements/REQUIREMENTS.md) | — | — | 2026-07-17 |
+| sid-iam-testing-platform | [REQUIREMENTS.md](../../sid-iam-testing-platform/docs/project-management/REQUIREMENTS.md) | — | — | 2026-07-17 |
+| microservice-testing-platform | [requirements.md](../../microservice-testing-platform/docs/project-management/requirements.md) | — | — | 2026-07-17 |
+| ai-testing-platform | [REQUIREMENTS.md](../../ai-testing-platform/docs/REQUIREMENTS.md) | — | — | 2026-07-17 |
+| playwright-demo | [REQUIREMENTS.md](../../playwright-demo/docs/requirements/REQUIREMENTS.md) | — | — | 2026-07-17 |
+| selenium-demo | [REQUIREMENTS.md](../../selenium-demo/docs/requirements/REQUIREMENTS.md) | — | — | 2026-07-17 |
+| robot-framework-demo | [REQUIREMENTS.md](../../robot-framework-demo/docs/requirements/REQUIREMENTS.md) | — | — | 2026-07-17 |
 
 ---
 
@@ -86,6 +91,7 @@
 | 日期 | 操作 | 内容 | 操作人 |
 |------|------|------|--------|
 | 2026-05-26 | 初始化 | 创建 Portfolio 需求台账，录入 PREQ-001 ~ PREQ-008 | Michael Zhou |
+| 2026-07-17 | 新增 | 录入 PREQ-016 (#42)、PREQ-017 (#18)；更新项目入口表指向 11 个项目实际文档路径 | Michael Zhou |
 | 2026-07-13 | 新增 | 仓库优化审计：录入 PREQ-009 ~ PREQ-015（对应 Issues #428-#434） | Michael Zhou |
 | 2026-07-14 | 补链 | PREQ-006 关联 Issue #437；新增维护规则：新需求必须同步创建 Issue | Michael Zhou |
 | 2026-07-15 | 修正 | 移除 PREQ-009/010/011/013/015（属于缺陷，已移至 defect-register 分配 PDEF-010~014）；PREQ-012/014 状态 → Refined | Michael Zhou |

--- a/k8s-auto-testing-platform/docs/requirements/REQUIREMENTS.md
+++ b/k8s-auto-testing-platform/docs/requirements/REQUIREMENTS.md
@@ -1,0 +1,25 @@
+# K8S Auto Testing Platform — Requirements
+
+## 功能需求
+
+| ID | 描述 | 优先级 |
+|----|------|--------|
+| FR-K8S-001 | HPA 扩缩容行为验证（上下限） | P0 |
+| FR-K8S-002 | Min/max 副本边界测试 | P0 |
+| FR-K8S-003 | CPU/内存阈值触发验证 | P0 |
+| FR-K8S-004 | Pod 故障注入与恢复（Chaos Mesh） | P0 |
+| FR-K8S-005 | 网络延迟/丢包混沌测试 | P1 |
+| FR-K8S-006 | 并发请求弹性测试 | P1 |
+| FR-K8S-007 | Locust 负载测试 | P1 |
+| FR-K8S-008 | Prometheus 指标收集 + Grafana 仪表盘 | P1 |
+| FR-K8S-009 | HPA 压力测试自动化脚本 | P1 |
+| FR-K8S-010 | Chaos Mesh CRD 集成 | P2 |
+| FR-K8S-011 | CSV 指标导出与报告 | P2 |
+
+## 非功能需求
+
+| ID | 类别 | 要求 |
+|----|------|------|
+| NFR-K8S-001 | 环境 | Kind 集群 + Metrics Server |
+| NFR-K8S-002 | 质量 | Black/isort/flake8/pylint 门禁 |
+| NFR-K8S-003 | 覆盖率 | pytest 覆盖率 ≥ 80% |

--- a/playwright-demo/docs/requirements/REQUIREMENTS.md
+++ b/playwright-demo/docs/requirements/REQUIREMENTS.md
@@ -1,0 +1,26 @@
+# Playwright Demo — Requirements
+
+## 功能需求
+
+| ID | 描述 | 优先级 |
+|----|------|--------|
+| FR-PW-001 | 跨浏览器测试（Chromium, Firefox, WebKit） | P0 |
+| FR-PW-002 | API CRUD 测试（12 测试） | P0 |
+| FR-PW-003 | UI 页面加载测试（标题/编码/性能预算） | P0 |
+| FR-PW-004 | UI 导航测试（外部链接/多标签页） | P1 |
+| FR-PW-005 | UI 网络测试（模拟/离线/延迟注入） | P1 |
+| FR-PW-006 | UI 响应式测试（3 视口 × 3 断言） | P1 |
+| FR-PW-007 | 视觉回归测试（toHaveScreenshot） | P1 |
+| FR-PW-008 | 无障碍审计（axe-core, WCAG 2.0 AA） | P1 |
+| FR-PW-009 | Page Object Model 模式 | P1 |
+| FR-PW-010 | 依赖注入 Fixture 系统 | P2 |
+| FR-PW-011 | 数据驱动测试（视口循环） | P2 |
+| FR-PW-012 | Trace Viewer 集成 | P2 |
+
+## 非功能需求
+
+| ID | 类别 | 要求 |
+|----|------|------|
+| NFR-PW-001 | 浏览器 | 3 引擎并行执行 |
+| NFR-PW-002 | 性能 | 页面加载 < 5000ms |
+| NFR-PW-003 | 报告 | 内置 Trace Viewer + Screenshot |

--- a/robot-framework-demo/docs/requirements/REQUIREMENTS.md
+++ b/robot-framework-demo/docs/requirements/REQUIREMENTS.md
@@ -1,0 +1,24 @@
+# Robot Framework Demo — Requirements
+
+## 功能需求
+
+| ID | 描述 | 优先级 |
+|----|------|--------|
+| FR-ROB-001 | Robot Framework 关键字驱动测试 | P0 |
+| FR-ROB-002 | Pabot 并行执行（N 进程） | P0 |
+| FR-ROB-003 | Selenium Grid 4 分布式浏览器（Chrome + Firefox） | P0 |
+| FR-ROB-004 | Rebot 报告合并 | P0 |
+| FR-ROB-005 | 导航功能测试（3 用例） | P0 |
+| FR-ROB-006 | 交互功能测试（3 用例） | P1 |
+| FR-ROB-007 | 多浏览器兼容性测试（3 用例） | P1 |
+| FR-ROB-008 | Docker Compose 网格环境编排 | P1 |
+| FR-ROB-009 | CI/CD GitHub Actions 集成 | P1 |
+| FR-ROB-010 | 共享资源库（通用关键字/变量） | P2 |
+
+## 非功能需求
+
+| ID | 类别 | 要求 |
+|----|------|------|
+| NFR-ROB-001 | 浏览器 | Selenium Grid Chrome + Firefox |
+| NFR-ROB-002 | 并行 | Pabot 进程数可配置 |
+| NFR-ROB-003 | 报告 | Rebot 合并 output.xml |

--- a/security-testing-demo/docs/requirements/REQUIREMENTS.md
+++ b/security-testing-demo/docs/requirements/REQUIREMENTS.md
@@ -1,0 +1,29 @@
+# Security Testing Demo — Requirements
+
+## 功能需求
+
+| ID | 描述 | 优先级 |
+|----|------|--------|
+| FR-SEC-001 | DVWA 安全测试（XSS, SQLi, CSRF, Auth, Headers） | P0 |
+| FR-SEC-002 | Juice Shop API 安全测试 | P0 |
+| FR-SEC-003 | OWASP ZAP 集成（基线/全量/API 扫描） | P0 |
+| FR-SEC-004 | Nessus Essentials 漏洞扫描 | P1 |
+| FR-SEC-005 | OpenVAS/GVM 开源扫描 | P1 |
+| FR-SEC-006 | SQLMap SQL 注入利用自动化 | P1 |
+| FR-SEC-007 | OWASP Top 10 2021 全量覆盖 | P1 |
+| FR-SEC-008 | 密码学失效测试（A02） | P1 |
+| FR-SEC-009 | 易受攻击组件测试（A06） | P1 |
+| FR-SEC-010 | 软件完整性测试（A08） | P2 |
+| FR-SEC-011 | 日志记录与监控失效测试（A09） | P2 |
+| FR-SEC-012 | SSRF 测试（A10） | P2 |
+| FR-SEC-013 | 多安全级别测试（低/中/高） | P2 |
+| FR-SEC-014 | Docker Compose 环境编排（ZAP + DVWA + Juice Shop） | P1 |
+| FR-SEC-015 | 分阶段学习指南（7 阶段） | P2 |
+
+## 非功能需求
+
+| ID | 类别 | 要求 |
+|----|------|------|
+| NFR-SEC-001 | CI | GitHub Actions 5 并行任务 |
+| NFR-SEC-002 | 安全 | 依赖安全扫描（safety） |
+| NFR-SEC-003 | 合规 | OWASP Top 10 2021 映射 |

--- a/selenium-demo/docs/requirements/REQUIREMENTS.md
+++ b/selenium-demo/docs/requirements/REQUIREMENTS.md
@@ -1,0 +1,24 @@
+# Selenium Demo — Requirements
+
+## 功能需求
+
+| ID | 描述 | 优先级 |
+|----|------|--------|
+| FR-SEL-001 | IWSVA 系统更新页面加载验证 | P0 |
+| FR-SEL-002 | 内核版本验证（前端 + SSH 后端） | P0 |
+| FR-SEL-003 | 补丁状态检查 | P0 |
+| FR-SEL-004 | UI 元素存在性断言 | P0 |
+| FR-SEL-005 | 错误场景测试（无效输入/超时/404） | P1 |
+| FR-SEL-006 | 自动失败产物捕获（截图/HTML/日志） | P1 |
+| FR-SEL-007 | Allure 测试报告集成 | P1 |
+| FR-SEL-008 | 数据驱动测试（DDT） | P1 |
+| FR-SEL-009 | 浏览器控制台日志提取 | P2 |
+| FR-SEL-010 | 并行执行支持 | P2 |
+
+## 非功能需求
+
+| ID | 类别 | 要求 |
+|----|------|------|
+| NFR-SEL-001 | 质量 | PEP8 + Google Docstring |
+| NFR-SEL-002 | 报告 | Allure + 失败产物 |
+| NFR-SEL-003 | 可追溯 | 测试用例 ID + RTM 映射 |


### PR DESCRIPTION
Closes #437

## Phase 1 — 台账修正
- req-register.md 项目入口表：指向 11 个项目实际 requirements 文档路径

## Phase 2 — 创建 6 份缺失需求文档
| 项目 | FR | NFR | 总计 |
|------|----|-----|------|
| k8s-auto-testing-platform | 11 | 3 | 14 |
| security-testing-demo | 15 | 3 | 18 |
| cicd-demo | 15 | 3 | 18 |
| playwright-demo | 12 | 3 | 15 |
| selenium-demo | 10 | 3 | 13 |
| robot-framework-demo | 10 | 3 | 13 |

## Phase 3 — Issue 需求对账
- 新增 PREQ-016 (#42 ECS+K3s)、PREQ-017 (#18 Mobile Demo)
- 所有 Open Issue 均有对应需求行

## Phase 4 — 同步流程
- how-to-use.md 新增 Issue ↔ 需求同步规范（创建/变更/审计时限）