### PR TITLE
docs(ai-testing): Stage 5 closing — sync test count to 92

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Michael Zhou's QA Portfolio - Test automation & DevOps demos.
 | 平台测试 | `microservice-testing-platform/` — Microservice (101 tests, 5 layers) | Node.js, Express, Jest, Redis, k6 | `microservice-testing-platform/CLAUDE.md` |
 | 性能测试 | `performance-testing-platform/` — k6 + JMeter dual-engine (148 unit + 31 integration + 33 perf) | k6, JMeter, Express, Grafana, InfluxDB | `performance-testing-platform/CLAUDE.md` |
 | 稳定性测试 | `k8s-auto-testing-platform/` — K8S HPA + Chaos (37 tests) | Python, Pytest, Chaos Mesh | `k8s-auto-testing-platform/CLAUDE.md` |
-| **AI 测试** | `ai-testing-platform/` — AI-Powered Testing Platform (72 tests) | Python, Pytest, Rule Engine | `ai-testing-platform/CLAUDE.md` |
+| **AI 测试** | `ai-testing-platform/` — AI-Powered Testing Platform (92 tests) | Python, Pytest, Rule Engine | `ai-testing-platform/CLAUDE.md` |
 
 > **Quick Commands**: 各项目的安装、运行、测试命令详见对应子项目 `CLAUDE.md`。
 
@@ -174,7 +174,7 @@ All workflows are in root `.github/workflows/` (GitHub ignores subdirectory work
 
 | Workflow | Project | Purpose |
 |----------|---------|---------|
-| `ai-testing-ci.yml` | ai-testing-platform | AI Testing CI: code quality + unit tests (72 tests, 82% coverage) |
+| `ai-testing-ci.yml` | ai-testing-platform | AI Testing CI: code quality + unit tests (92 tests, 82% coverage) |
 | `api-testing-ci.yml` | api-testing-demo | Validate collections → Newman tests (280+ assertions) |
 | `robot-framework-ci.yml` | robot-framework-demo | Robot Framework / Pabot parallel + Selenium Grid + Rebot merge (9 tests) |
 | `cicd-demo-pr.yml` | cicd-demo | PR Gate: lint + unit/contract tests + Docker build + quick security scan |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Test automation, performance testing, and DevOps demonstration projects.
 
 | Project | Description | Tech Stack |
 |---------|-------------|------------|
-| [ai-testing-platform](./ai-testing-platform/) | AI-Powered Testing Platform — 智能测试用例生成 + 缺陷预测 + 脚本生成 (72 tests) | Python, Pytest, Rule Engine |
+| [ai-testing-platform](./ai-testing-platform/) | AI-Powered Testing Platform — 智能测试用例生成 + 缺陷预测 + 脚本生成 + 代码扫描 (92 tests) | Python, Pytest, Rule Engine |
 
 ### DevOps
 

--- a/ai-testing-platform/CLAUDE.md
+++ b/ai-testing-platform/CLAUDE.md
@@ -27,6 +27,9 @@ flake8 src/ tests/ --max-line-length=120 --extend-ignore=E203
 
 # 从需求文档生成测试用例（示例）
 python scripts/generate_test_cases.py
+
+# 扫描真实代码并输出风险排行（REQ-AI-003）
+python scripts/scan_and_predict.py --path src/
 ```
 
 ## 核心模块
@@ -34,8 +37,9 @@ python scripts/generate_test_cases.py
 | 模块 | 路径 | 职责 |
 |------|------|------|
 | TestCaseGenerator | `src/case_generator/generator.py` | 从需求文本/git diff 生成测试用例，支持 CRUD、安全、边界、DBCS |
-| DefectPredictor | `src/defect_predictor/predictor.py` | 基于代码度量预测高风险模块 |
+| DefectPredictor | `src/defect_predictor/predictor.py` | 基于代码度量预测高风险模块（7 因子，含 dependency/staleness） |
 | ScriptGenerator | `src/script_generator/generator.py` | 从测试规范生成 pytest 脚本 |
+| CodeScanner | `src/code_scanner/scanner.py` | 自动扫描真实 Python 文件采集 ModuleMetrics（ast + radon + git） |
 | LLMEvaluator | `src/llm_evaluator/` | LLM 输出质量评测（需 API Key） |
 
 ## 测试说明
@@ -44,6 +48,7 @@ python scripts/generate_test_cases.py
 |--------|------|
 | `generation` | TestCaseGenerator 单元测试 |
 | `prediction` | DefectPredictor 单元测试 |
+| `scanner` | CodeScanner 单元测试 |
 | `llm` | LLM 集成测试（需 OPENAI_API_KEY） |
 | `integration` | 端到端集成测试 |
 | `P0/P1/P2` | 测试优先级 |
@@ -52,5 +57,5 @@ python scripts/generate_test_cases.py
 
 Workflow: `.github/workflows/ai-testing-ci.yml`
 - code-quality（black/isort/flake8/ruff）
-- unit-tests（72 tests，排除 llm + integration）
+- unit-tests（92 tests，排除 llm + integration）
 - verify-by-module（按模块分组验证）

--- a/ai-testing-platform/README.md
+++ b/ai-testing-platform/README.md
@@ -23,11 +23,11 @@
 
 | 指标 | 数值 |
 |------|------|
-| 测试用例 | 72 |
-| 核心引擎 | 3（TestCaseGenerator / DefectPredictor / ScriptGenerator）|
+| 测试用例 | 92 |
+| 核心引擎 | 4（TestCaseGenerator / DefectPredictor / ScriptGenerator / CodeScanner）|
 | 测试覆盖率 | 82.50% |
-| 外部依赖 | 零（纯 Python 标准库）|
-| 全部通过 | 72/72 PASSED |
+| 外部依赖 | radon（圈复杂度分析）|
+| 全部通过 | 92/92 PASSED |
 
 ---
 
@@ -166,16 +166,20 @@ ai-testing-platform/
 │   │   └── generator.py           # TestCaseGenerator — 需求文本 → 测试用例
 │   ├── defect_predictor/
 │   │   └── predictor.py           # DefectPredictor — 代码度量 → 风险报告
-│   └── script_generator/
-│       └── generator.py           # ScriptGenerator — 测试规范 → Pytest 脚本
+│   ├── script_generator/
+│   │   └── generator.py           # ScriptGenerator — 测试规范 → Pytest 脚本
+│   └── code_scanner/
+│       └── scanner.py             # CodeScanner — 扫描 .py 文件 → ModuleMetrics
 ├── tests/
 │   ├── conftest.py                 # 根级 fixtures
-│   ├── test_case_generator/        # 14 个测试
+│   ├── test_case_generator/        # 23 个测试
 │   │   └── test_case_generator.py
-│   ├── test_defect_predictor/      # 13 个测试
+│   ├── test_defect_predictor/      # 15 个测试
 │   │   └── test_defect_predictor.py
-│   └── test_script_generator/      # 16 个测试
-│       └── test_script_generator.py
+│   ├── test_script_generator/      # 16 个测试
+│   │   └── test_script_generator.py
+│   └── test_code_scanner/          # 18 个测试
+│       └── test_scanner.py
 ├── docs/
 │   ├── REQUIREMENTS.md             # 功能需求
 │   ├── FEASIBILITY.md              # 可行性分析
@@ -187,7 +191,8 @@ ai-testing-platform/
 │       └── generated-login-test-cases.json  # 自动生成的测试用例（示例输出）
 ├── scripts/
 │   ├── integration-test.sh         # LLM 集成测试入口
-│   └── generate_test_cases.py      # 需求文档 → 测试用例生成脚本
+│   ├── generate_test_cases.py      # 需求文档 → 测试用例生成脚本
+│   └── scan_and_predict.py         # 扫描真实代码 → 缺陷风险排行
 ├── pytest.ini
 ├── pyproject.toml
 ├── requirements.txt
@@ -203,7 +208,8 @@ ai-testing-platform/
 | 语言 | Python 3.9+ |
 | 测试框架 | Pytest, pytest-cov, pytest-html |
 | AI 方法 | 规则引擎、关键词提取、加权评分模型 |
-| 代码质量 | black, flake8, isort |
+| 代码分析 | radon（圈复杂度）、ast（依赖分析）、git subprocess |
+| 代码质量 | black, flake8, isort, ruff |
 | CI/CD | GitHub Actions |
 
 ---
@@ -224,4 +230,4 @@ ai-testing-platform/
 
 ---
 
-*阶段: Phase 3 完成（实现+测试）| License: MIT*
+*阶段: 完成（REQ-AI-001/002/003 全部 Done）| License: MIT*


### PR DESCRIPTION
## Summary
- Sync test count from 72→92 across CLAUDE.md, README.md, ai-testing-platform/CLAUDE.md and README.md
- Stage 5 closing documentation for ai-testing-platform REQ-AI-001~003

## Changes
- `CLAUDE.md`: update ai-testing test count
- `README.md`: update ai-testing test count
- `ai-testing-platform/CLAUDE.md`: sync counts and coverage
- `ai-testing-platform/README.md`: sync counts and coverage

## Test plan
- [ ] No code changes, docs-only
- [ ] Verify test counts are consistent across all updated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)