### PR TITLE
fix(microservice-pt): sanitize pagination & validate inputs

### DIFF
--- a/microservice-testing-platform/docs/qa/defect-register.md
+++ b/microservice-testing-platform/docs/qa/defect-register.md
@@ -1,0 +1,33 @@
+# microservice-testing-platform Defect & Waiver Register
+
+制度文档: `../../../docs/project-management/defect-tracking/README.md`
+Waiver 政策: `../../../docs/project-management/defect-tracking/waiver-policy.md`
+
+## 严重度定义
+
+| 级别 | 含义 | Gate 影响 |
+|------|------|-----------|
+| P0 / Critical | 核心功能不可用，数据不可信 | 立即 BLOCKED |
+| P1 / High | 重要功能降级，影响验收结论 | 标记 Blocking 时 BLOCKED |
+| P2 / Medium | 非核心功能异常，有 workaround | 不阻塞，可 waiver |
+| P3 / Low | 轻微问题，不影响功能或结论 | 不阻塞，记录即可 |
+
+## 活跃缺陷登记表
+
+| Defect ID | GitHub Issue | 标题摘要 | 严重度 | Blocking? | 发现日期 | 状态 | 关联 Waiver | 备注 |
+|-----------|--------------|----------|--------|-----------|----------|------|-------------|------|
+| _(无)_ | | | | | | | | |
+
+## 已关闭缺陷历史
+
+| Defect ID | GitHub Issue | 标题摘要 | 严重度 | 关闭日期 | 关闭方式 | 关联 Commit / PR |
+|-----------|--------------|----------|--------|----------|----------|-------------------|
+| MS-DEF-001 | — | NaN 分页参数导致 SQLite datatype mismatch 500 | P1 | 2026-07-27 | Fixed: list() 中 sanitize page/limit（parseInt + Math.max） | 本 PR |
+| MS-DEF-002 | — | 非数字 quantity/unitPrice 穿透模型验证，DB 存入 NaN | P1 | 2026-07-27 | Fixed: 3 个模型 + inventory route 增加 typeof 检查 | 本 PR |
+| MS-DEF-003 | — | 负数 page 偏移在 SQLite 中被视为 0，返回所有行 | P3 | 2026-07-27 | Fixed: page/limit 统一 sanitize 到 ≥ 1 | 本 PR |
+
+## 变更日志
+
+| 日期 | 变更内容 | 操作人 |
+|------|----------|--------|
+| 2026-07-27 | 初始建表，登记 MS-DEF-001~003 | QA |

--- a/microservice-testing-platform/services/inventory-service/src/models/inventory.js
+++ b/microservice-testing-platform/services/inventory-service/src/models/inventory.js
@@ -19,7 +19,7 @@ function getByProductId(productId) {
 function deduct(productId, quantity, orderId) {
   const db = getDb();
 
-  if (!quantity || quantity <= 0) {
+  if (typeof quantity !== 'number' || !quantity || quantity <= 0) {
     const err = new Error(ERROR_CODES.VALIDATION_ERROR);
     err.code = ERROR_CODES.VALIDATION_ERROR;
     throw err;

--- a/microservice-testing-platform/services/inventory-service/src/routes/inventory.js
+++ b/microservice-testing-platform/services/inventory-service/src/routes/inventory.js
@@ -23,7 +23,7 @@ router.get('/:productId', (req, res) => {
 
 router.post('/:productId/deduct', (req, res, next) => {
   const { quantity, orderId } = req.body;
-  if (!quantity || !orderId) {
+  if (typeof quantity !== 'number' || !quantity || !orderId) {
     return res.status(400).json({
       error: ERROR_CODES.VALIDATION_ERROR,
       message: 'quantity and orderId are required',

--- a/microservice-testing-platform/services/order-service/src/models/order.js
+++ b/microservice-testing-platform/services/order-service/src/models/order.js
@@ -22,12 +22,12 @@ function create({ productId, quantity, unitPrice }) {
     err.code = ERROR_CODES.VALIDATION_ERROR;
     throw err;
   }
-  if (!quantity || quantity <= 0) {
+  if (typeof quantity !== 'number' || !quantity || quantity <= 0) {
     const err = new Error(ERROR_CODES.VALIDATION_ERROR);
     err.code = ERROR_CODES.VALIDATION_ERROR;
     throw err;
   }
-  if (!unitPrice || unitPrice <= 0) {
+  if (typeof unitPrice !== 'number' || !unitPrice || unitPrice <= 0) {
     const err = new Error(ERROR_CODES.VALIDATION_ERROR);
     err.code = ERROR_CODES.VALIDATION_ERROR;
     throw err;
@@ -50,6 +50,8 @@ function getById(id) {
 
 function list({ status, page = 1, limit = 10 } = {}) {
   const db = getDb();
+  page = Math.max(1, parseInt(page, 10) || 1);
+  limit = Math.max(1, parseInt(limit, 10) || 10);
   const offset = (page - 1) * limit;
 
   let query = 'SELECT * FROM orders';

--- a/microservice-testing-platform/services/payment-service/src/models/payment.js
+++ b/microservice-testing-platform/services/payment-service/src/models/payment.js
@@ -16,7 +16,7 @@ function generateId() {
 function processPayment({ orderId, amount, correlationId }) {
   const db = getDb();
 
-  if (!amount || amount <= 0) {
+  if (typeof amount !== 'number' || !amount || amount <= 0) {
     const err = new Error(ERROR_CODES.VALIDATION_ERROR);
     err.code = ERROR_CODES.VALIDATION_ERROR;
     throw err;

--- a/microservice-testing-platform/tests/unit/order-service/order-model.test.js
+++ b/microservice-testing-platform/tests/unit/order-service/order-model.test.js
@@ -127,26 +127,21 @@ describe('Order Model', () => {
   });
 
   // UT-O-12: List - negative page number
-  test('treats negative page offset as no offset, returns all rows', () => {
-    orderModel.create({ productId: 'PROD-001', quantity: 1, unitPrice: 10 });
+  test('defaults to page 1 for negative page value', () => {
     const result = orderModel.list({ page: -1, limit: 10 });
-    // SQLite treats negative OFFSET as 0 (no offset)
-    expect(result.data.length).toBeGreaterThan(0);
-    expect(result.pagination.page).toBe(-1);
+    expect(result.pagination.page).toBe(1);
   });
 
   // UT-O-13: List - zero limit
-  test('returns empty data for zero limit', () => {
+  test('defaults to limit 10 for zero limit value', () => {
     const result = orderModel.list({ page: 1, limit: 0 });
-    expect(result.data).toEqual([]);
-    expect(result.pagination.limit).toBe(0);
+    expect(result.pagination.limit).toBe(10);
   });
 
-  // UT-O-14: List - non-numeric page causes SQL error
-  test('throws on non-numeric page value', () => {
-    expect(() => {
-      orderModel.list({ page: 'abc', limit: 10 });
-    }).toThrow();
+  // UT-O-14: List - non-numeric page
+  test('defaults to page 1 for non-numeric page value', () => {
+    const result = orderModel.list({ page: 'abc', limit: 10 });
+    expect(result.pagination.page).toBe(1);
   });
 
   // UT-O-15: Create - extreme values (large quantity * unitPrice)

--- a/microservice-testing-platform/tests/unit/order-service/order-routes.test.js
+++ b/microservice-testing-platform/tests/unit/order-service/order-routes.test.js
@@ -101,11 +101,11 @@ describe('Order Routes', () => {
       expect(res.body.data).toEqual([]);
     });
 
-    test('returns 500 for non-numeric page value', async () => {
+    test('defaults to page 1 for non-numeric page value', async () => {
       const res = await request(app).get('/api/orders?page=abc');
 
-      // NaN propagates to SQLite LIMIT/OFFSET causing datatype mismatch
-      expect(res.status).toBe(500);
+      expect(res.status).toBe(200);
+      expect(res.body.pagination.page).toBe(1);
     });
   });
 


### PR DESCRIPTION
**Summary**: Fix MS-DEF-001~003 — NaN/negative pagination params cause SQLite datatype mismatch 500; non-numeric quantity/unitPrice bypass model validation.
- Sanitize page/limit via parseInt + Math.max (>= 1)
- Add typeof checks in order/payment/inventory models + inventory route
- Register defect history in `docs/qa/defect-register.md`

**Test Plan**: `npm run test:all` (117 tests), lint, prettier format — all PASS