### PR TITLE
docs(microservice-pt): link MS-DEF issues to defect register (#581)

### DIFF
--- a/microservice-testing-platform/docs/qa/defect-register.md
+++ b/microservice-testing-platform/docs/qa/defect-register.md
@@ -22,12 +22,13 @@ Waiver 政策: `../../../docs/project-management/defect-tracking/waiver-policy.m
 
 | Defect ID | GitHub Issue | 标题摘要 | 严重度 | 关闭日期 | 关闭方式 | 关联 Commit / PR |
 |-----------|--------------|----------|--------|----------|----------|-------------------|
-| MS-DEF-001 | — | NaN 分页参数导致 SQLite datatype mismatch 500 | P1 | 2026-07-27 | Fixed: list() 中 sanitize page/limit（parseInt + Math.max） | 本 PR |
-| MS-DEF-002 | — | 非数字 quantity/unitPrice 穿透模型验证，DB 存入 NaN | P1 | 2026-07-27 | Fixed: 3 个模型 + inventory route 增加 typeof 检查 | 本 PR |
-| MS-DEF-003 | — | 负数 page 偏移在 SQLite 中被视为 0，返回所有行 | P3 | 2026-07-27 | Fixed: page/limit 统一 sanitize 到 ≥ 1 | 本 PR |
+| MS-DEF-001 | [#581](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/581) | NaN 分页参数导致 SQLite datatype mismatch 500 | P1 | 2026-07-27 | Fixed: list() 中 sanitize page/limit（parseInt + Math.max） | PR #580 |
+| MS-DEF-002 | [#582](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/582) | 非数字 quantity/unitPrice 穿透模型验证，DB 存入 NaN | P1 | 2026-07-27 | Fixed: 3 个模型 + inventory route 增加 typeof 检查 | PR #580 |
+| MS-DEF-003 | [#583](https://github.com/zhoujuxi2028/michael-zhou-qa-portfolio/issues/583) | 负数 page 偏移在 SQLite 中被视为 0，返回所有行 | P3 | 2026-07-27 | Fixed: page/limit 统一 sanitize 到 ≥ 1 | PR #580 |
 
 ## 变更日志
 
 | 日期 | 变更内容 | 操作人 |
 |------|----------|--------|
 | 2026-07-27 | 初始建表，登记 MS-DEF-001~003 | QA |
+| 2026-08-04 | 补建 GitHub issue #581~#583 并关闭，回填关联 PR #580 | QA |


### PR DESCRIPTION
**Summary**: 补建 MS-DEF-001~003 GitHub issue (#581~#583) 并关闭，回填 defect-register 关联 Issue 与 PR #580。
**Test Plan**: 纯文档变更，无代码影响。